### PR TITLE
Adding WalletId (Credited and Debited) to a Transaction

### DIFF
--- a/MangoPay/Transaction.php
+++ b/MangoPay/Transaction.php
@@ -74,6 +74,18 @@ class Transaction extends Libraries\EntityBase {
     public $Nature;
     
     /**
+     * Debited wallet Id
+     * @var int
+     */
+    public $DebitedWalletId;
+    
+    /**
+     * Credited wallet Id
+     * @var int  
+     */
+    public $CreditedWalletId;
+    
+    /**
      * Get array with mapping which property is object and what type of object 
      * @return array
      */


### PR DESCRIPTION
MangoPay's API handles fields **CreditedWalletId** and **DebitedWalletId** in response of `Users->GetTransactions($userId);` call but are not casted by the SDK