### PR TITLE
Correction in composer.json : doesn't need more than php5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "stable",
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.4.0",
         "ext-curl": "*",
         "ext-openssl": "*",
         "psr/log": "^1.0"


### PR DESCRIPTION
Composer refuses to install this SDK when php5.5 isn't available, but it doesn't use any of php5.5's new features and it perfectly works on 5.4

We should really modify the _require_ line related to php in composer.json