### PR TITLE
Serialize method __toString() to MangoPay\Libraries\Error

### DIFF
--- a/MangoPay/Libraries/Error.php
+++ b/MangoPay/Libraries/Error.php
@@ -20,4 +20,13 @@ class Error
      * @access public
      */
     public $Errors;
+    
+    /**
+     * Return the stdClass error serialized as string
+     * @access public 
+     */
+    public function __toString()
+    {
+        return serialize($this->Errors);
+    }
 }


### PR DESCRIPTION
Reference to https://github.com/Mangopay/mangopay2-php-sdk/issues/76 issue

You can return json_encode() instead serialize() if you see more properly. But that object Error needs to be converted to string sometimes.