### PR TITLE
Fix PHPDoc for EntityBase.Id property

### DIFF
--- a/MangoPay/Libraries/EntityBase.php
+++ b/MangoPay/Libraries/EntityBase.php
@@ -8,8 +8,9 @@ namespace MangoPay\Libraries;
 abstract class EntityBase extends Dto
 {
     /**
-     * @var Int Unique identifier
-     * (At this moment type is Integer - in the feature will be GUID)
+     * @var string Unique identifier
+     *
+     * At this moment, identifier is a numeric string - in the future, will be GUID.
      */
     public $Id;
     


### PR DESCRIPTION
Tell me if I'm wrong, but `Id` seems to always be a numeric string, not an integer.

Out of curiosity, do you still plan to move to `GUID` at some point?