### PR TITLE
Add constants for statuses

### DIFF
--- a/MangoPay/CardPreAuthorizationPaymentStatus.php
+++ b/MangoPay/CardPreAuthorizationPaymentStatus.php
@@ -1,0 +1,13 @@
+<?php
+namespace MangoPay;
+
+/**
+ * Pre-authorization payment statuses
+ */
+class CardPreAuthorizationPaymentStatus
+{
+    const Canceled = 'CANCELED';
+    const Expired = 'EXPIRED';
+    const Validated = 'VALIDATED';
+    const Waiting = 'WAITING';
+}

--- a/MangoPay/CardPreAuthorizationStatus.php
+++ b/MangoPay/CardPreAuthorizationStatus.php
@@ -1,0 +1,12 @@
+<?php
+namespace MangoPay;
+
+/**
+ * Pre-authorization statuses
+ */
+class CardPreAuthorizationStatus
+{
+    const Created = 'CREATED';
+    const Succeeded = 'SUCCEEDED';
+    const Failed = 'FAILED';
+}

--- a/MangoPay/CardRegistrationStatus.php
+++ b/MangoPay/CardRegistrationStatus.php
@@ -1,0 +1,12 @@
+<?php
+namespace MangoPay;
+
+/**
+ * Card registration statuses
+ */
+class CardRegistrationStatus
+{
+    const Created = 'CREATED';
+    const Validated = 'VALIDATED';
+    const Error = 'ERROR';
+}

--- a/MangoPay/PayInStatus.php
+++ b/MangoPay/PayInStatus.php
@@ -1,0 +1,12 @@
+<?php
+namespace MangoPay;
+
+/**
+ * PayIn statuses
+ */
+class PayInStatus
+{
+    const Created = 'CREATED';
+    const Succeeded = 'SUCCEEDED';
+    const Failed = 'FAILED';
+}

--- a/MangoPay/PayOutStatus.php
+++ b/MangoPay/PayOutStatus.php
@@ -1,0 +1,12 @@
+<?php
+namespace MangoPay;
+
+/**
+ * PayOut statuses
+ */
+class PayOutStatus
+{
+    const Created = 'CREATED';
+    const Succeeded = 'SUCCEEDED';
+    const Failed = 'FAILED';
+}

--- a/demos/paymentDirect/payment.php
+++ b/demos/paymentDirect/payment.php
@@ -23,7 +23,7 @@ try {
     $cardRegister->RegistrationData = isset($_GET['data']) ? 'data=' . $_GET['data'] : 'errorCode=' . $_GET['errorCode'];
     $updatedCardRegister = $mangoPayApi->CardRegistrations->Update($cardRegister);
 
-    if ($updatedCardRegister->Status != 'VALIDATED' || !isset($updatedCardRegister->CardId))
+    if ($updatedCardRegister->Status != \MangoPay\CardRegistrationStatus::Validated || !isset($updatedCardRegister->CardId))
         die('<div style="color:red;">Cannot create card. Payment has not been created.<div>');
 
     // get created virtual card object

--- a/demos/paymentDirect/payment.php
+++ b/demos/paymentDirect/payment.php
@@ -60,7 +60,7 @@ try {
     $createdPayIn = $mangoPayApi->PayIns->Create($payIn);
 
     // if created Pay-in object has status SUCCEEDED it's mean that all is fine
-    if ($createdPayIn->Status == 'SUCCEEDED') {
+    if ($createdPayIn->Status == \MangoPay\PayInStatus::Succeeded) {
         print '<div style="color:green;">'.
                     'Pay-In has been created successfully. '
                     .'Pay-In Id = ' . $createdPayIn->Id 

--- a/demos/workflow/scripts/kyc.php
+++ b/demos/workflow/scripts/kyc.php
@@ -11,7 +11,7 @@ $result2 = $mangoPayApi->Users->CreateKycPageFromFile($_SESSION["MangoPayDemo"][
 //submit the doc for validation
 $KycDocument = new MangoPay\KycDocument();
 $KycDocument->Id = $KycDocumentId;
-$KycDocument->Status = "VALIDATION_ASKED";
+$KycDocument->Status = \MangoPay\KycDocumentStatus::ValidationAsked;
 $result3 = $mangoPayApi->Users->UpdateKycDocument($_SESSION["MangoPayDemo"]["UserNatural"], $KycDocument);
 
 

--- a/demos/workflow/scripts/payin-card-direct.php
+++ b/demos/workflow/scripts/payin-card-direct.php
@@ -19,6 +19,6 @@ $result = $mangoPayApi->PayIns->Create($PayIn);
 //Display result
 pre_dump($result);
 $_SESSION["MangoPayDemo"]["PayInCardDirect"] = $result->Id;
-if ($result->ExecutionDetails->SecureModeNeeded && $result->Status!="FAILED") {
+if ($result->ExecutionDetails->SecureModeNeeded && $result->Status!=\MangoPay\PayInStatus::Failed) {
 	$nextButton = array("url"=>$result->ExecutionDetails->SecureModeRedirectURL, "text"=>"Go to 3DS payment page");
 }

--- a/demos/workflow/scripts/preauth.php
+++ b/demos/workflow/scripts/preauth.php
@@ -13,6 +13,6 @@ $result = $mangoPayApi->CardPreAuthorizations->Create($CardPreAuthorization);
 //Display result
 pre_dump($result);
 $_SESSION["MangoPayDemo"]["PreAuth"] = $result->Id;
-if ($result->SecureModeNeeded && $result->Status!="FAILED") {
+if ($result->SecureModeNeeded && $result->Status!=\MangoPay\CardPreAuthorizationStatus::Failed) {
 	$nextButton = array("url"=>$result->SecureModeRedirectURL, "text"=>"Go to 3DS payment page");
 }

--- a/tests/cases/cardPreAuthorizations.php
+++ b/tests/cases/cardPreAuthorizations.php
@@ -13,7 +13,7 @@ class CardPreAuthorizations extends Base {
         
         $this->assertTrue($cardPreAuthorization->Id > 0);
         $this->assertIdentical($cardPreAuthorization->Status, \MangoPay\CardPreAuthorizationStatus::Succeeded);
-        $this->assertIdentical($cardPreAuthorization->PaymentStatus, 'WAITING');
+        $this->assertIdentical($cardPreAuthorization->PaymentStatus, \MangoPay\CardPreAuthorizationPaymentStatus::Waiting);
         $this->assertIdentical($cardPreAuthorization->ExecutionType, 'DIRECT');
         $this->assertNull($cardPreAuthorization->PayInId);
     }
@@ -29,11 +29,11 @@ class CardPreAuthorizations extends Base {
     
     function test_CardPreAuthorization_Update() {
         $cardPreAuthorization = $this->getJohnsCardPreAuthorization();
-        $cardPreAuthorization->PaymentStatus = "CANCELED ";
+        $cardPreAuthorization->PaymentStatus = \MangoPay\CardPreAuthorizationPaymentStatus::Canceled;
         
         $resultCardPreAuthorization = $this->_api->CardPreAuthorizations->Update($cardPreAuthorization);
         
         $this->assertIdentical($resultCardPreAuthorization->Status, \MangoPay\CardPreAuthorizationStatus::Succeeded);
-        $this->assertIdentical($resultCardPreAuthorization->PaymentStatus, 'CANCELED');
+        $this->assertIdentical($resultCardPreAuthorization->PaymentStatus, \MangoPay\CardPreAuthorizationPaymentStatus::Canceled);
     }
 }

--- a/tests/cases/cardPreAuthorizations.php
+++ b/tests/cases/cardPreAuthorizations.php
@@ -12,7 +12,7 @@ class CardPreAuthorizations extends Base {
         $cardPreAuthorization = $this->getJohnsCardPreAuthorization();
         
         $this->assertTrue($cardPreAuthorization->Id > 0);
-        $this->assertIdentical($cardPreAuthorization->Status, 'SUCCEEDED');
+        $this->assertIdentical($cardPreAuthorization->Status, \MangoPay\CardPreAuthorizationStatus::Succeeded);
         $this->assertIdentical($cardPreAuthorization->PaymentStatus, 'WAITING');
         $this->assertIdentical($cardPreAuthorization->ExecutionType, 'DIRECT');
         $this->assertNull($cardPreAuthorization->PayInId);
@@ -33,7 +33,7 @@ class CardPreAuthorizations extends Base {
         
         $resultCardPreAuthorization = $this->_api->CardPreAuthorizations->Update($cardPreAuthorization);
         
-        $this->assertIdentical($resultCardPreAuthorization->Status, "SUCCEEDED");
+        $this->assertIdentical($resultCardPreAuthorization->Status, \MangoPay\CardPreAuthorizationStatus::Succeeded);
         $this->assertIdentical($resultCardPreAuthorization->PaymentStatus, 'CANCELED');
     }
 }

--- a/tests/cases/cardRegistrations.php
+++ b/tests/cases/cardRegistrations.php
@@ -17,7 +17,7 @@ class CardRegistrations extends Base {
         $this->assertNotNull($cardRegistration->CardRegistrationURL);
         $this->assertEqual($user->Id, $cardRegistration->UserId);
         $this->assertEqual('EUR', $cardRegistration->Currency);
-        $this->assertEqual('CREATED', $cardRegistration->Status);
+        $this->assertEqual(\MangoPay\CardRegistrationStatus::Created, $cardRegistration->Status);
     }
     
     function test_CardRegistrations_Get() {
@@ -38,7 +38,7 @@ class CardRegistrations extends Base {
 
         $this->assertEqual($registrationData, $getCardRegistration->RegistrationData);
         $this->assertNotNull($getCardRegistration->CardId);
-        $this->assertIdentical('VALIDATED', $getCardRegistration->Status);
+        $this->assertIdentical(\MangoPay\CardRegistrationStatus::Validated, $getCardRegistration->Status);
         $this->assertIdentical('000000', $getCardRegistration->ResultCode);
     }
     
@@ -52,7 +52,7 @@ class CardRegistrations extends Base {
         
         $getCardRegistration = $this->_api->CardRegistrations->Update($cardRegistration);
 
-        $this->assertEqual("ERROR", $getCardRegistration->Status);
+        $this->assertEqual(\MangoPay\CardRegistrationStatus::Error, $getCardRegistration->Status);
         $this->assertNotNull($getCardRegistration->ResultCode);
         $this->assertNotNull($getCardRegistration->ResultMessage);
     }

--- a/tests/cases/payIns.php
+++ b/tests/cases/payIns.php
@@ -30,7 +30,7 @@ class PayIns extends Base {
         $this->assertIdentical($payIn->ExecutionType, \MangoPay\PayInExecutionType::Web);
         $this->assertIsA($payIn->ExecutionDetails, '\MangoPay\PayInExecutionDetailsWeb');
         $this->assertIdenticalInputProps($payIn, $getPayIn);
-        $this->assertIdentical($getPayIn->Status, 'CREATED');
+        $this->assertIdentical($getPayIn->Status, \MangoPay\PayInStatus::Created);
         $this->assertNull($getPayIn->ExecutionDate);
         $this->assertNotNull($getPayIn->ExecutionDetails->RedirectURL);
         $this->assertNotNull($getPayIn->ExecutionDetails->ReturnURL);
@@ -55,7 +55,7 @@ class PayIns extends Base {
         $this->assertIsA($payIn->Fees, '\MangoPay\Money');
         $this->assertEqual($user->Id, $payIn->AuthorId);
         $this->assertEqual($wallet->Balance->Amount, $beforeWallet->Balance->Amount + $payIn->CreditedFunds->Amount);
-        $this->assertEqual('SUCCEEDED', $payIn->Status);
+        $this->assertEqual(\MangoPay\PayInStatus::Succeeded, $payIn->Status);
         $this->assertEqual('PAYIN', $payIn->Type);
     }
 
@@ -122,7 +122,7 @@ class PayIns extends Base {
         $this->assertIsA($createPayIn->CreditedFunds, '\MangoPay\Money');
         $this->assertIsA($createPayIn->Fees, '\MangoPay\Money');
         $this->assertEqual($user->Id, $createPayIn->AuthorId);
-        $this->assertEqual('SUCCEEDED', $createPayIn->Status);
+        $this->assertEqual(\MangoPay\PayInStatus::Succeeded, $createPayIn->Status);
         $this->assertEqual('PAYIN', $createPayIn->Type);
     }
     
@@ -154,7 +154,7 @@ class PayIns extends Base {
         $this->assertEqual(\MangoPay\PayInExecutionType::Direct, $createPayIn->ExecutionType);
         $this->assertIsA($createPayIn->ExecutionDetails, '\MangoPay\PayInExecutionDetailsDirect');
         $this->assertEqual($user->Id, $createPayIn->AuthorId);
-        $this->assertEqual('CREATED', $createPayIn->Status);
+        $this->assertEqual(\MangoPay\PayInStatus::Created, $createPayIn->Status);
         $this->assertEqual('PAYIN', $createPayIn->Type);
         $this->assertNotNull($createPayIn->PaymentDetails->WireReference);
         $this->assertIsA($createPayIn->PaymentDetails->BankAccount, '\MangoPay\BankAccount');
@@ -232,7 +232,7 @@ class PayIns extends Base {
         $this->assertIsA($createPayIn->ExecutionDetails, '\MangoPay\PayInExecutionDetailsWeb');
         $this->assertEqual("FR", $createPayIn->ExecutionDetails->Culture);
         $this->assertEqual($user->Id, $createPayIn->AuthorId);
-        $this->assertEqual('CREATED', $createPayIn->Status);
+        $this->assertEqual(\MangoPay\PayInStatus::Created, $createPayIn->Status);
         $this->assertEqual('PAYIN', $createPayIn->Type);
         $this->assertIsA($createPayIn->DebitedFunds, '\MangoPay\Money');
         $this->assertEqual(10000, $createPayIn->DebitedFunds->Amount);

--- a/tests/cases/payOuts.php
+++ b/tests/cases/payOuts.php
@@ -23,7 +23,7 @@ class PayOuts extends Base {
         
         $this->assertIdentical($payOut->Id, $payOutGet->Id);
         $this->assertIdentical($payOut->PaymentType, $payOutGet->PaymentType);
-        $this->assertIdentical($payOutGet->Status, 'CREATED');
+        $this->assertIdentical($payOutGet->Status, \MangoPay\PayOutStatus::Created);
         $this->assertIdenticalInputProps($payOut, $payOutGet);
         $this->assertNull($payOutGet->ExecutionDate);
     }
@@ -32,7 +32,7 @@ class PayOuts extends Base {
     function test_PayOuts_Create_BankWire_FailsCauseNotEnoughMoney() {
         $payOut = $this->getJohnsPayOutBankWire();
         
-        $this->assertIdentical('FAILED', $payOut->Status);
+        $this->assertIdentical(\MangoPay\PayOutStatus::Failed, $payOut->Status);
     }
 }
 


### PR DESCRIPTION
#### Problem

There are constant wrappers for `KycDocument`, `Dispute` and `DisputeDocument` statuses (from #88), but some others (like `PayIn` status) are missing.

#### Solution

Mimic what has been done before and add missing constant wrappers:
- add constants for `PayIn`, `PayOut`, `CardRegistration`, `CardPreAuthorization` status;
- add constants for `CardPreAuthorization` payment status.

#### Tests
```
$ cd tests/suites/
$ php all.php 
all.php
Skip: Cannot test creating dispute document because there's no dispute with expected status in the disputes list.
Skip: Cannot test creating dispute document page because there's no dispute with expected status in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be contested in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be resubmited in the disputes list.
Skip: Cannot test closing dispute because there's no available disputes with expected status in the disputes list.
Skip: Cannot test getting dispute's document because there's no dispute with expected status in the disputes list.
Skip: Cannot test submitting dispute's documents because there's no dispute with expected status in the disputes list.
Skip: Cannot test getting repudiation because dispute has no transaction.
OK
Test cases run: 16/16, Passes: 606, Failures: 0, Exceptions: 0
```