### PR TITLE
Use Composer PSR-4 autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "psr/log": "^1.0"
     },    
     "autoload": {
-        "psr-4": { "MangoPay\\": "" },
-        "files": ["MangoPay/Autoloader.php"]
+        "psr-4": { "MangoPay\\": "MangoPay/" }
     }
 }


### PR DESCRIPTION
It uses Composer to load the clases instead of the custom autoloader `MangoPay/Autoloader.php`.

Maybe `MangoPay/Autoloader.php` can be removed, since composer `autoloader.php` is included in the releases?