### PR TITLE
Add constants for LegalPersonType

### DIFF
--- a/MangoPay/LegalPersonType.php
+++ b/MangoPay/LegalPersonType.php
@@ -1,0 +1,11 @@
+<?php
+namespace MangoPay;
+
+/**
+ * Legal Person types
+ */
+class LegalPersonType
+{
+    const Business = 'BUSINESS';
+    const Organization = 'ORGANIZATION';
+}

--- a/demos/users_create.php
+++ b/demos/users_create.php
@@ -25,7 +25,7 @@ try {
     // CREATE LEGAL USER
     $legalUser = new MangoPay\UserLegal();
     $legalUser->Name = 'Name Legal Test';
-    $legalUser->LegalPersonType = 'BUSINESS';
+    $legalUser->LegalPersonType = \MangoPay\LegalPersonType::Business;
     $legalUser->Email = 'legal@testmangopay.com';
 	$legalUser->LegalRepresentativeFirstName = "Bob";
 	$legalUser->LegalRepresentativeLastName = "Briant";

--- a/demos/workflow/scripts/user-create-legal.php
+++ b/demos/workflow/scripts/user-create-legal.php
@@ -1,7 +1,7 @@
 <?php
 $User = new MangoPay\UserLegal();
 $User->Name = "Name Legal Test";
-$User->LegalPersonType = "BUSINESS";
+$User->LegalPersonType = \MangoPay\LegalPersonType::Business;
 $User->Email = "legal@testmangopay.com";
 $User->LegalRepresentativeFirstName = "Bob";
 $User->LegalRepresentativeLastName = "Briant";

--- a/tests/cases/base.php
+++ b/tests/cases/base.php
@@ -165,7 +165,7 @@ abstract class Base extends \UnitTestCase {
             $user = new \MangoPay\UserLegal();
             $user->Name = "MartixSampleOrg";
             $user->Email = "mail@test.com";
-            $user->LegalPersonType = "BUSINESS";
+            $user->LegalPersonType = \MangoPay\LegalPersonType::Business;
             $user->HeadquartersAddress = $this->getNewAddress();
             $user->LegalRepresentativeFirstName = $john->FirstName;
             $user->LegalRepresentativeLastName = $john->LastName;

--- a/tests/cases/users.php
+++ b/tests/cases/users.php
@@ -39,7 +39,7 @@ class Users extends Base {
         $user->HeadquartersAddress->Region = 'Region';
         $user->Name = "SomeOtherSampleOrg";
         $user->Email = "mail@test.com";
-        $user->LegalPersonType = "BUSINESS";
+        $user->LegalPersonType = \MangoPay\LegalPersonType::Business;
         $user->LegalRepresentativeFirstName = "FirstName";
         $user->LegalRepresentativeLastName = "LastName";
         $user->LegalRepresentativeAddress = new \MangoPay\Address();


### PR DESCRIPTION
## Problem

There are constants wrapper for `kycDocument` but not for `LegalPerson`.

## Solution

Mimic what has been done before and add missing constant wrapper:

- add constants for LegalPersonType ('BUSINESS', 'ORGANISATION')

## Tests
```
$ php all.php                                      
all.php
Exception 1!
Unexpected exception of type [MangoPay\Libraries\ResponseException] with message [Internal server error. Internal Server Error] in [/home/jules/v3/mangopay2-php-sdk/MangoPay/Libraries/RestTool.php line 333]
	in test_PayIns_Create_DirectDebitDirect
	in MangoPay\Tests\PayIns
	in ../cases/payIns.php
	in MangoPay\Tests\All
1) Expected true, got [Boolean: false] at [/home/jules/v3/mangopay2-php-sdk/tests/cases/kycDocuments.php line 35]
	in test_KycDocuments_GetAll_SortByCreationDate
	in MangoPay\Tests\KycDocuments
	in ../cases/kycDocuments.php
	in MangoPay\Tests\All
Skip: Cannot test creating dispute document because there's no dispute with expected status in the disputes list.
Skip: Cannot test creating dispute document page because there's no dispute with expected status in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be contested in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be resubmited in the disputes list.
Skip: Cannot test closing dispute because there's no available disputes with expected status in the disputes list.
Skip: Cannot test getting dispute's document because there's no dispute with expected status in the disputes list.
Skip: Cannot test submitting dispute's documents because there's no dispute with expected status in the disputes list.
Skip: Cannot test getting repudiation because dispute has no transaction.
FAILURES!!!
Test cases run: 17/17, Passes: 621, Failures: 1, Exceptions: 1
```

It fails but there is no more error than on master. See issues https://github.com/Mangopay/mangopay2-php-sdk/issues/101.

