### PR TITLE
Add constants for KycLevel

### DIFF
--- a/MangoPay/KycLevel.php
+++ b/MangoPay/KycLevel.php
@@ -1,0 +1,11 @@
+<?php
+namespace MangoPay;
+
+/**
+ * KYC Level
+ */
+class KycLevel
+{
+    const Light = 'LIGHT';
+    const Regular = 'REGULAR';
+}


### PR DESCRIPTION
## Problem

There are no constants wrapper for `kycLevel`

## Solution

Mimic what has been done before and add missing constant wrapper:

## Tests

```
1) Expected true, got [Boolean: false] at [/home/jules/v3/mangopay2-php-sdk/tests/cases/kycDocuments.php line 35]
	in test_KycDocuments_GetAll_SortByCreationDate
	in MangoPay\Tests\KycDocuments
	in ../cases/kycDocuments.php
	in MangoPay\Tests\All
Exception 1!
Unexpected exception of type [MangoPay\Libraries\ResponseException] with message [Internal server error. Internal Server Error] in [/home/jules/v3/mangopay2-php-sdk/MangoPay/Libraries/RestTool.php line 333]
	in test_Transfers_Get
	in MangoPay\Tests\Transfers
	in ../cases/transfers.php
	in MangoPay\Tests\All
Skip: Cannot test creating dispute document because there's no dispute with expected status in the disputes list.
Skip: Cannot test creating dispute document page because there's no dispute with expected status in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be contested in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be resubmited in the disputes list.
Skip: Cannot test closing dispute because there's no available disputes with expected status in the disputes list.
Skip: Cannot test getting dispute's document because there's no dispute with expected status in the disputes list.
Skip: Cannot test submitting dispute's documents because there's no dispute with expected status in the disputes list.
Skip: Cannot test getting repudiation because dispute has no transaction.
FAILURES!!!
Test cases run: 17/17, Passes: 641, Failures: 1, Exceptions: 1
```

Same errors as on master. So I assume it's good! 
See https://github.com/Mangopay/mangopay2-php-sdk/issues/109