### PR TITLE
Add soletrader LegalPersonType constant

### DIFF
--- a/MangoPay/LegalPersonType.php
+++ b/MangoPay/LegalPersonType.php
@@ -8,4 +8,5 @@ class LegalPersonType
 {
     const Business = 'BUSINESS';
     const Organization = 'ORGANIZATION';
+    const Soletrader = 'SOLETRADER';
 }


### PR DESCRIPTION
## Problem

There are no constant for the recently added LegalPersonType `SOLETRADER`.

## Solution

Add a constant for the Sole Trader

## Tests

```
php all.php 
all.php
1) Expected true, got [Boolean: false] at [/home/jules/v3/mangopay2-php-sdk/tests/cases/kycDocuments.php line 35]
	in test_KycDocuments_GetAll_SortByCreationDate
	in MangoPay\Tests\KycDocuments
	in ../cases/kycDocuments.php
	in MangoPay\Tests\All
Exception 1!
Unexpected exception of type [MangoPay\Libraries\ResponseException] with message [Internal server error. Internal Server Error] in [/home/jules/v3/mangopay2-php-sdk/MangoPay/Libraries/RestTool.php line 333]
	in test_Transfers_Get
	in MangoPay\Tests\Transfers
	in ../cases/transfers.php
	in MangoPay\Tests\All
Skip: Cannot test creating dispute document because there's no dispute with expected status in the disputes list.
Skip: Cannot test creating dispute document page because there's no dispute with expected status in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be contested in the disputes list.
Skip: Cannot test contesting dispute because there's no disputes that can be resubmited in the disputes list.
Skip: Cannot test closing dispute because there's no available disputes with expected status in the disputes list.
Skip: Cannot test getting dispute's document because there's no dispute with expected status in the disputes list.
Skip: Cannot test submitting dispute's documents because there's no dispute with expected status in the disputes list.
Skip: Cannot test getting repudiation because dispute has no transaction.
FAILURES!!!
Test cases run: 17/17, Passes: 641, Failures: 1, Exceptions: 1
```

Same errors as on master. See #109 