### PR TITLE
Fix typo

### DIFF
--- a/demos/workflow/scripts/payout.php
+++ b/demos/workflow/scripts/payout.php
@@ -1,7 +1,7 @@
 <?php
 $PayOut = new \MangoPay\PayOut();
 $PayOut->AuthorId = $_SESSION["MangoPayDemo"]["UserLegal"];
-$PayOut->DebitedWalletID = $_SESSION["MangoPayDemo"]["WalletForLegalUser"];
+$PayOut->DebitedWalletId = $_SESSION["MangoPayDemo"]["WalletForLegalUser"];
 $PayOut->DebitedFunds = new \MangoPay\Money();
 $PayOut->DebitedFunds->Currency = "EUR";
 $PayOut->DebitedFunds->Amount = 610;


### PR DESCRIPTION
Property names are case sensitive, the `$PayOut->DebitedWalletID` property does not exist. This change will update the example so it uses the correct property ([See PayOut.php](https://github.com/Mangopay/mangopay2-php-sdk/blob/master/MangoPay/PayOut.php#L13) for reference).