### PR TITLE
Read version from constant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  tag  to modify the version"
+
+tag:
+	$(if $(TAG),,$(error TAG is not defined. Pass via "make tag TAG=2.5.1"))
+	@echo Tagging $(TAG)
+	sed -i 's/^    "version": ".*",/    "version": "'$(TAG)'",/' composer.json
+	sed -i "s/const VERSION = '.*';/const VERSION = '$(TAG)';/" MangoPay/Libraries/RestTool.php
+	php -l MangoPay/Libraries/RestTool.php

--- a/MangoPay/Libraries/RestTool.php
+++ b/MangoPay/Libraries/RestTool.php
@@ -8,6 +8,8 @@ use Psr\Log\LoggerInterface;
  */
 class RestTool
 {
+    const VERSION = '2.5.0';
+
     /**
      * Root/parent instance that holds the OAuthToken and Configuration instance
      * @var \MangoPay\MangoPayApi
@@ -330,9 +332,7 @@ class RestTool
         array_push($this->_requestHttpHeaders, self::$_JSON_HEADER);
 
         // Add User-Agent Header
-        $composerJsonData = file_get_contents(__DIR__ . '/../../composer.json');
-        $decodedComposerJson = json_decode($composerJsonData, true);
-        array_push($this->_requestHttpHeaders, 'User-Agent: MangoPay V2 PHP/' . $decodedComposerJson['version']);
+        array_push($this->_requestHttpHeaders, 'User-Agent: MangoPay V2 PHP/' . self::VERSION);
 
 
         // Authentication http header


### PR DESCRIPTION
fixes https://github.com/Mangopay/mangopay2-php-sdk/issues/149

Add `RestTool::VERSION` and use this constant to craft the `User-Agent` header.

Provide a `Makefile` to help updating the version number in `composer.json` and `RestTool.php` for each new tag.

### Usage
```sh
# update the tag in relevant files
$ make tag TAG=2.5.1

# check the diff before tagging and pushing upstream
$ git diff
```