### PR TITLE
Bugfix/shipping address mapping

### DIFF
--- a/MangoPay/PayInPaymentDetailsPaypal.php
+++ b/MangoPay/PayInPaymentDetailsPaypal.php
@@ -15,7 +15,7 @@ class PayInPaymentDetailsPaypal extends Libraries\Dto implements PayInPaymentDet
     {
         $subObjects = parent::GetSubObjects();
 
-        $subObjects['ShippingAddress'] = '\Mangopay\ShippingAddress';
+        $subObjects['ShippingAddress'] = '\MangoPay\ShippingAddress';
 
         return $subObjects;
     }

--- a/MangoPay/ShippingAddress.php
+++ b/MangoPay/ShippingAddress.php
@@ -29,7 +29,7 @@ class ShippingAddress extends Libraries\Dto
     {
         $subObjects = parent::GetSubObjects();
 
-        $subObjects['Address'] = '\Mangopay\Address';
+        $subObjects['Address'] = '\MangoPay\Address';
 
         return $subObjects;
     }


### PR DESCRIPTION
There are fatal errors when creating PayPal pay-ins. The reason is misspelt namespaces for ShippingAddress related fields:

```
PHP Fatal error:  Uncaught Error: Class '\Mangopay\ShippingAddress' not found in .../vendor/mangopay/php-sdk-v2/MangoPay/Libraries/ApiBase.php:339

PHP Fatal error:  Uncaught Error: Class '\Mangopay\Address' not found in .../vendor/mangopay/php-sdk-v2/MangoPay/Libraries/ApiBase.php:339
```