### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "mangopay/php-sdk-v2",
     "description": "SDK PHP for Mangopay api V2",
-    "version": "2.6.4",
     "minimum-stability": "stable",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
As stated in https://getcomposer.org/doc/04-schema.md#version:

> Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.