### PR TITLE
Fix incorrect ProofOfIdentity property name for LegalUser

### DIFF
--- a/MangoPay/UserLegal.php
+++ b/MangoPay/UserLegal.php
@@ -70,7 +70,7 @@ class UserLegal extends User
      *
      * @var string
      */
-    public $ProofOfIdentity;
+    public $LegalRepresentativeProofOfIdentity;
     
     /**
      *


### PR DESCRIPTION
Fix bug: #225 