### PR TITLE
Adding getter/setter for configuration injection

### DIFF
--- a/MangoPay/MangoPayApi.php
+++ b/MangoPay/MangoPayApi.php
@@ -234,6 +234,22 @@ class MangoPayApi
     {
         return $this->logger;
     }
+    
+    /**
+     * @return Libraries\Configuration
+     */
+    public function getConfig()
+    {
+        return $this->Config;
+    }
+
+    /**
+     * @param Libraries\Configuration $Config
+     */
+    public function setConfig($Config)
+    {
+        $this->Config = $Config;
+    }
 
     /**
      * @param \MangoPay\Libraries\HttpBase $httpClient


### PR DESCRIPTION
Adding a getter/setter for the `Config` property of the `MangoPayApi` object will allow injection of the configuration through a service container.