### PR TITLE
Money::$Amount typehint is `int`, not `Long`

### DIFF
--- a/MangoPay/Money.php
+++ b/MangoPay/Money.php
@@ -15,7 +15,7 @@ class Money extends Libraries\Dto
     
     /**
      * The currency amount of money
-     * @var Long
+     * @var int
      */
     public $Amount;
 }


### PR DESCRIPTION
Long is not a valid PHP object, and according to your documentation, the amount must be an int