### PR TITLE
PHPDoc: user Id is a string, not an int

### DIFF
--- a/MangoPay/ApiUsers.php
+++ b/MangoPay/ApiUsers.php
@@ -118,7 +118,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Create bank account for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\BankAccount $bankAccount Entity of bank account object
      * @return \MangoPay\BankAccount Create bank account object
      */
@@ -130,7 +130,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get all bank accounts for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\Sorting $sorting Object to sorting data
      *
@@ -143,7 +143,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get bank account for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param int $bankAccountId Bank account Id
      *
      * @return \MangoPay\BankAccount Entity of bank account object
@@ -155,7 +155,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Save a bank account
-     * @param int $userId
+     * @param string $userId
      * @param \MangoPay\BankAccount $bankAccount
      * @return \MangoPay\BankAccount Entity of bank account object
      */
@@ -166,7 +166,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get all wallets for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\Sorting $sorting Object to sorting data
      *
@@ -179,7 +179,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get all transactions for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\FilterTransactions $filter Object to filter data
      * @param \MangoPay\Sorting $sorting Object to sorting data
@@ -193,7 +193,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get all cards for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\Sorting $sorting Object to sorting data
      *
@@ -206,7 +206,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Create new KYC document
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\KycDocument $kycDocument
      * @param string $idempotencyKey Key for response replication
      * @return \MangoPay\KycDocument Document returned from API
@@ -218,7 +218,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get all KYC documents for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\Sorting $sorting Object to sorting data
      * @param \MangoPay\FilterKycDocuments $filter Object to filter data
@@ -232,7 +232,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get KYC document
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param string $kycDocumentId Document identifier
      * @return \MangoPay\KycDocument Document returned from API
      */
@@ -243,7 +243,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get all mandates for user
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\FilterTransactions $filter Object to filter data
      * @param \MangoPay\Sorting $sorting Object to sorting data
@@ -257,7 +257,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get mandates for user and bank account
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param int $bankAccountId Bank account Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\FilterTransactions $filter Object to filter data
@@ -272,7 +272,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Save KYC document
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param \MangoPay\KycDocument $kycDocument Document to save
      * @return \MangoPay\KycDocument Document returned from API
      */
@@ -283,7 +283,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Create page for Kyc document
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param int $kycDocumentId KYC Document Id
      * @param \MangoPay\KycPage $kycPage KYC Page
      * @throws \MangoPay\Libraries\Exception
@@ -301,7 +301,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Create page for Kyc document from file
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @param int $kycDocumentId KYC Document Id
      * @param string $filePath File path
      * @throws \MangoPay\Libraries\Exception
@@ -329,7 +329,7 @@ class ApiUsers extends Libraries\ApiBase
 
     /**
      * Get user EMoney
-     * @param int $userId User Id
+     * @param string $userId User Id
      * @return \MangoPay\EMoney EMoney obhect returned from API
      */
     public function GetEMoney($userId)

--- a/MangoPay/Libraries/ApiBase.php
+++ b/MangoPay/Libraries/ApiBase.php
@@ -213,7 +213,7 @@ abstract class ApiBase
      * @param string $methodKey Key with request data
      * @param object $entity Entity object
      * @param object $responseClassName Name of entity class from response
-     * @param int $entityId Entity identifier
+     * @param string $entityId Entity identifier
      * @return object Response data
      */
     protected function CreateObject($methodKey, $entity, $responseClassName = null, $entityId = null, $subEntityId = null, $idempotencyKey = null)
@@ -244,7 +244,7 @@ abstract class ApiBase
     /**
      * Get entity object from API
      * @param string $methodKey Key with request data
-     * @param int $entityId Entity identifier
+     * @param string $entityId Entity identifier
      * @param object $responseClassName Name of entity class from response
      * @param int $secondEntityId Entity identifier for second entity
      * @return object Response data
@@ -268,7 +268,7 @@ abstract class ApiBase
      * @param string $methodKey Key with request data
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param object $responseClassName Name of entity class from response
-     * @param int $entityId Entity identifier
+     * @param string $entityId Entity identifier
      * @param object $filter Object to filter data
      * @param \MangoPay\Sorting $sorting Object to sorting data
      * @return object[] Response data


### PR DESCRIPTION
Follows #261 and #263 on phpdoc types.

EntityBase::Id is a string,  but all calls to `$userId` required `int` which seems wrong (the official documentation says `string` too).