### PR TITLE
Allow filtering of bank accounts

### DIFF
--- a/MangoPay/ApiUsers.php
+++ b/MangoPay/ApiUsers.php
@@ -133,12 +133,13 @@ class ApiUsers extends Libraries\ApiBase
      * @param int $userId User Id
      * @param \MangoPay\Pagination $pagination Pagination object
      * @param \MangoPay\Sorting $sorting Object to sorting data
+     * @param \MangoPay\FilterBankAccounts $filter Filtering object
      *
      * @return array Array with bank account entities
      */
-    public function GetBankAccounts($userId, & $pagination = null, $sorting = null)
+    public function GetBankAccounts($userId, & $pagination = null, $sorting = null, $filter = null)
     {
-        return $this->GetList('users_allbankaccount', $pagination, 'MangoPay\BankAccount', $userId, null, $sorting);
+        return $this->GetList('users_allbankaccount', $pagination, 'MangoPay\BankAccount', $userId, $filter, $sorting);
     }
 
     /**

--- a/MangoPay/FilterBankAccounts.php
+++ b/MangoPay/FilterBankAccounts.php
@@ -1,0 +1,14 @@
+<?php
+namespace MangoPay;
+
+/**
+ * Filtering object for Bank Accounts
+ */
+class FilterBankAccounts extends Libraries\Dto
+{
+    /**
+     * Active {true, false}
+     * @var string
+     */
+    public $Active;
+}

--- a/tests/cases/UsersTest.php
+++ b/tests/cases/UsersTest.php
@@ -332,6 +332,26 @@ class UsersTest extends Base
         $this->assertTrue($list[0]->CreationDate >= $list[1]->CreationDate);
     }
 
+    function test_Users_BankAccounts_Filtering()
+    {
+        $john = $this->getJohn();
+        $this->getJohnsAccount();
+        self::$JohnsAccount = null;
+        $this->getJohnsAccount();
+        $pagination = new \MangoPay\Pagination(1, 12);
+        $filter = new \MangoPay\FilterBankAccounts();
+        $filter->Active = 'false';
+
+        $inactiveList = $this->_api->Users->GetBankAccounts($john->Id, $pagination, null, $filter);
+        $this->assertCount(1, $inactiveList);
+
+        $filter = new \MangoPay\FilterBankAccounts();
+        $filter->Active = 'true';
+
+        $activeList = $this->_api->Users->GetBankAccounts($john->Id, $pagination, null, $filter);
+        $this->assertCount(12, $activeList);
+    }
+
     function test_Users_UpdateBankAccount()
     {
         $john = $this->getJohn();


### PR DESCRIPTION
This PR aims to add the missing (active/inactive) filter handing for bank accounts. The functionality is already present in the API but is currently missing in the SDK. This makes pagination a bit tricky to implement.