### PR TITLE
Adding the GET Repudiation method.

### DIFF
--- a/MangoPay/ApiRepudiations.php
+++ b/MangoPay/ApiRepudiations.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MangoPay;
 
 /**
@@ -6,6 +7,13 @@ namespace MangoPay;
  */
 class ApiRepudiations extends Libraries\ApiBase
 {
+    /**
+     * @param string $repudiationId
+     */
+    public function Get($repudiationId)
+    {
+        return $this->GetObject('repudiation_get', $repudiationId, '\MangoPay\Repudiation');
+    }
 
     /**
      * Retrieves a list of Refunds pertaining to a certain Repudiation
@@ -16,6 +24,6 @@ class ApiRepudiations extends Libraries\ApiBase
      */
     public function GetRefunds($repudiationId, & $pagination = null, $filter = null, $sorting = null)
     {
-        return $this->GetList('refunds_get_for_repudiation', $pagination, '\MangoPay\Refund', $repudiationId, $filter, $sorting);
+        return $this->GetList('refunds_get_for_repudiation', $pagination, '\MangoPay\Repudiation', $repudiationId, $filter, $sorting);
     }
 }

--- a/MangoPay/Libraries/ApiBase.php
+++ b/MangoPay/Libraries/ApiBase.php
@@ -62,6 +62,8 @@ abstract class ApiBase
         'payins_get' => array( '/payins/%s', RequestType::GET ),
         'payins_createrefunds' => array( '/payins/%s/refunds', RequestType::POST ),
 
+        'repudiation_get' => array('/repudiations/%s', RequestType::GET),
+
         'get_extended_card_view' => array( '/payins/card/web/%s/extended', RequestType::GET ),
 
         'payouts_bankwire_create' => array( '/payouts/bankwire/', RequestType::POST ),


### PR DESCRIPTION
It is not possible at the moment to fetch a single Repudiation object using the SDK. This method is a simple get_object on this entrypoint. 