### PR TITLE
Improve Status/Type annotations and add missing classes

### DIFF
--- a/MangoPay/ApiUsers.php
+++ b/MangoPay/ApiUsers.php
@@ -287,6 +287,7 @@ class ApiUsers extends Libraries\ApiBase
      * @param string $userId User Id
      * @param int $kycDocumentId KYC Document Id
      * @param \MangoPay\KycPage $kycPage KYC Page
+     * @return bool `true` if the upload was successful, `false` otherwise
      * @throws \MangoPay\Libraries\Exception
      */
     public function CreateKycPage($userId, $kycDocumentId, $kycPage, $idempotencyKey = null)
@@ -310,6 +311,7 @@ class ApiUsers extends Libraries\ApiBase
      * @param string $userId User Id
      * @param int $kycDocumentId KYC Document Id
      * @param string $filePath File path
+     * @return bool `true` if the upload was successful, `false` otherwise
      * @throws \MangoPay\Libraries\Exception
      */
     public function CreateKycPageFromFile($userId, $kycDocumentId, $filePath, $idempotencyKey = null)

--- a/MangoPay/CardPreAuthorization.php
+++ b/MangoPay/CardPreAuthorization.php
@@ -22,15 +22,16 @@ class CardPreAuthorization extends Libraries\EntityBase
     public $DebitedFunds;
 
     /**
-     * Status of the PreAuthorization: CREATED, SUCCEEDED, FAILED
+     * Status of the PreAuthorization
      * @var string
+     * @see \MangoPay\CardPreAuthorizationStatus
      */
     public $Status;
 
     /**
-     * The status of the payment after the PreAuthorization:
-     * WAITING, CANCELED, EXPIRED, VALIDATED
+     * The status of the payment after the PreAuthorization
      * @var string
+     * @see \MangoPay\CardPreAuthorizationPaymentStatus
      */
     public $PaymentStatus;
 

--- a/MangoPay/CardRegistration.php
+++ b/MangoPay/CardRegistration.php
@@ -69,6 +69,7 @@ class CardRegistration extends Libraries\EntityBase
     /**
      * Status
      * @var string
+     * @see \MangoPay\CardRegistrationStatus
      */
     public $Status;
         

--- a/MangoPay/DeclaredUbo.php
+++ b/MangoPay/DeclaredUbo.php
@@ -15,13 +15,15 @@ class DeclaredUbo
 
     /**
      * Validation status of this declared UBO.
-     * @var \MangoPay\DeclaredUboStatus
+     * @var string
+     * @see \MangoPay\DeclaredUboStatus
      */
     public $Status;
 
     /**
      * Reason why the declared UBO is not valid.
-     * @var \MangoPay\UboRefusedReasonType
+     * @var string
+     * @see \MangoPay\UboRefusedReasonType
      */
     public $RefusedReasonType;
 

--- a/MangoPay/Dispute.php
+++ b/MangoPay/Dispute.php
@@ -16,12 +16,14 @@ class Dispute extends Libraries\EntityBase
     /**
      * The type of transaction that is disputed
      * @var string
+     * @see \MangoPay\TransactionType
      */
     public $InitialTransactionType;
 
      /**
      * The type of dispute
-     * @var \MangoPay\DisputeType
+     * @var string
+     * @see \MangoPay\DisputeType
      */
     public $DisputeType;
 
@@ -51,7 +53,8 @@ class Dispute extends Libraries\EntityBase
 
     /**
      * The current status of the dispute
-     * @var \MangoPay\DisputeStatus
+     * @var string
+     * @see \MangoPay\DisputeStatus
      */
     public $Status;
 
@@ -89,7 +92,7 @@ class Dispute extends Libraries\EntityBase
             'DisputeReason' => '\MangoPay\DisputeReason',
             'DisputedFunds' => '\MangoPay\Money',
             'ContestedFunds' => '\MangoPay\Money'
-            );
+        );
     }
     
     /**

--- a/MangoPay/DisputeDocument.php
+++ b/MangoPay/DisputeDocument.php
@@ -14,13 +14,15 @@ class DisputeDocument extends Libraries\Document
 	
     /**
      * Type of dispute document
-     * @var \MangoPay\DisputeDocumentType
+     * @var string
+     * @see \MangoPay\DisputeDocumentType
      */
     public $Type;
     
     /**
      * Status of dispute document
-     * @var \MangoPay\DisputeDocumentStatus
+     * @var string
+     * @see \MangoPay\DisputeDocumentStatus
      */
     public $Status;
 }

--- a/MangoPay/DisputeReason.php
+++ b/MangoPay/DisputeReason.php
@@ -10,7 +10,8 @@ class DisputeReason extends Libraries\Dto
     
     /**
      * Dispute's reason type
-     * @var \MangoPay\DisputeReasonType
+     * @var string
+     * @see \MangoPay\DisputeReasonType
      */
     public $DisputeReasonType;
     

--- a/MangoPay/FilterDisputeDocuments.php
+++ b/MangoPay/FilterDisputeDocuments.php
@@ -8,15 +8,14 @@ class FilterDisputeDocuments extends FilterBase
 {
 
     /**
-     * DisputeDocumentStatus {CREATED, VALIDATION_ASKED, VALIDATED, REFUSED}
      * @var string
+     * @see \MangoPay\DisputeDocumentStatus
      */
     public $Status;
 
     /**
-     * DisputeDocumentType {DELIVERY_PROOF, INVOICE, REFUND_PROOF, USER_CORRESPONDANCE, USER_ACCEPTANCE_PROOF,
-     * PRODUCT_REPLACEMENT_PROOF, OTHER}
      * @var string
+     * @see \MangoPay\DisputeDocumentType
      */
     public $Type;
 }

--- a/MangoPay/FilterDisputes.php
+++ b/MangoPay/FilterDisputes.php
@@ -8,15 +8,14 @@ class FilterDisputes extends FilterBase
 {
 
     /**
-     * DisputeType {CONTESTABLE, NOT_CONTESTABLE, RETRIEVAL}
      * @var string
+     * @see \MangoPay\DisputeType
      */
     public $DisputeType;
 
     /**
-     * DisputeStatus {CREATED, PENDING_CLIENT_ACTION, SUBMITTED, PENDING_BANK_ACTION,
-     * REOPENED_PENDING_CLIENT_ACTION, CLOSED}
      * @var string
+     * @see DisputeStatus
      */
     public $Status;
 }

--- a/MangoPay/FilterKycDocuments.php
+++ b/MangoPay/FilterKycDocuments.php
@@ -6,16 +6,15 @@ namespace MangoPay;
  */
 class FilterKycDocuments extends FilterBase
 {
-    
     /**
-     * KycDocumentStatus {CREATED, VALIDATION_ASKED, VALIDATED, REFUSED}
      * @var string
+     * @see \MangoPay\KycDocumentStatus
      */
     public $Status;
-    
+
     /**
-     * KycDocumentType {IDENTITY_PROOF, REGISTRATION_PROOF, ARTICLES_OF_ASSOCIATION, SHAREHOLDER_DECLARATION, ADDRESS_PROOF}
-     * @var string 
+     * @var string
+     * @see \MangoPay\KycDocumentType
      */
     public $Type;
 }

--- a/MangoPay/FilterPreAuthorizations.php
+++ b/MangoPay/FilterPreAuthorizations.php
@@ -14,15 +14,15 @@ class FilterPreAuthorizations extends Libraries\Dto
 
     /**
      * Status of the PreAuthorizations
-     * {CREATED, SUCCEEDED, FAILED}
      * @var string
+     * @see \MangoPay\CardPreAuthorizationStatus
      */
     public $Status;
 
     /**
      * Status of the payment after the PreAuthorization
-     * {WAITING, CANCELED, EXPIRED, VALIDATED}
      * @var string
+     * @see \MangoPay\CardPreAuthorizationPaymentStatus
      */
     public $PaymentStatus;
 }

--- a/MangoPay/FilterRefunds.php
+++ b/MangoPay/FilterRefunds.php
@@ -8,14 +8,13 @@ class FilterRefunds extends Libraries\Dto
 {
 
     /**
-     * TransactionStatus {CREATED, SUCCEEDED, FAILED}
      * Multiple values separated by commas are allowed
      * @var string
+     * @see \MangoPay\RefundStatus
      */
     public $Status;
 
     /**
-     * The result code of the transaction
      * Multiple values separated by commas are allowed
      * @var string
      */

--- a/MangoPay/FilterReports.php
+++ b/MangoPay/FilterReports.php
@@ -228,8 +228,8 @@ class FilterReports extends FilterTransactions
      * @var string
      */
     public $MaxDebitedFundsCurrency;
-    
-        /**
+
+    /**
      * Minimum Fees amount
      * @var int
      */

--- a/MangoPay/FilterTransactions.php
+++ b/MangoPay/FilterTransactions.php
@@ -7,25 +7,24 @@ namespace MangoPay;
 class FilterTransactions extends FilterBase
 {
     /**
-     * TransactionStatus {CREATED, SUCCEEDED, FAILED}
      * @var string
+     * @see \MangoPay\TransactionStatus
      */
     public $Status;
     
     /**
-     * TransactionType {PAYIN, PAYOUT, TRANSFER}
      * @var string
+     * @see \MangoPay\TransactionType
      */
     public $Type;
     
     /**
-     * TransactionNature {REGULAR, REFUND, REPUDIATION, SETTLEMENT}
      * @var string
+     * @see \MangoPay\TransactionNature
      */
     public $Nature;
 
     /**
-     * Transaction's result code
      * @var string
      */
     public $ResultCode;

--- a/MangoPay/Hook.php
+++ b/MangoPay/Hook.php
@@ -13,20 +13,20 @@ class Hook extends Libraries\EntityBase
     public $Url;
         
     /**
-     * Status: ENABLED, DISABLED
      * @var string
+     * @see \MangoPay\HookStatus
      */
     public $Status;
     
     /**
-     * Validity: VALID, INVALID
      * @var string
+     * @see \MangoPay\HookValidity
      */
     public $Validity;
     
     /**
-     * EventType. See constants in MangoPay\EventType for allowed values.
      * @var string
+     * @see \MangoPay\EventType
      */
     public $EventType;
 }

--- a/MangoPay/HookStatus.php
+++ b/MangoPay/HookStatus.php
@@ -1,0 +1,10 @@
+<?php
+namespace MangoPay;
+
+final class HookStatus
+{
+    const Disabled = 'DISABLED';
+    const Enabled = 'ENABLED';
+
+    private function __construct() {}
+}

--- a/MangoPay/HookValidity.php
+++ b/MangoPay/HookValidity.php
@@ -1,0 +1,11 @@
+<?php
+namespace MangoPay;
+
+final class HookValidity
+{
+    const Unknown = 'UNKNOWN';
+    const Valid = 'VALID';
+    const Invalid = 'INVALID';
+
+    private function __construct() {}
+}

--- a/MangoPay/KycDocument.php
+++ b/MangoPay/KycDocument.php
@@ -7,19 +7,18 @@ namespace MangoPay;
 class KycDocument extends Libraries\Document
 {
     /**
-     * Document type
-     * @var string (See \MangoPay\KycDocumentType)
+     * @var string
+     * @see \MangoPay\KycDocumentType
      */
     public $Type;
     
     /**
-     * Document status
-     * @var string (See \MangoPay\KycDocumentStatus)
+     * @var string
+     * @see \MangoPay\KycDocumentStatus
      */
     public $Status;
     
     /**
-     * User identifier
      * @var string
      */
     public $UserId;

--- a/MangoPay/Mandate.php
+++ b/MangoPay/Mandate.php
@@ -51,8 +51,9 @@ class Mandate extends Libraries\EntityBase
     public $UserId;
 
     /**
-     * Status of the mandate: CREATED, SUBMITTED, ACTIVE, FAILED
-     * @var \MangoPay\MandateStatus
+     * Status of the mandate
+     * @var string
+     * @see \MangoPay\MandateStatus
      */
     public $Status;
 

--- a/MangoPay/MandateStatus.php
+++ b/MangoPay/MandateStatus.php
@@ -1,18 +1,7 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: cosmi
- * Date: 11-Sep-18
- * Time: 13:54
- */
 
 namespace MangoPay;
 
-/**
- * Mandate statuses
- * Class MandateStatus
- * @package MangoPay
- */
 class MandateStatus
 {
     const Created = "CREATED";

--- a/MangoPay/RefundStatus.php
+++ b/MangoPay/RefundStatus.php
@@ -1,0 +1,11 @@
+<?php
+namespace MangoPay;
+
+final class RefundStatus
+{
+    const Created = 'CREATED';
+    const Succeeded = 'SUCCEEDED';
+    const Failed = 'FAILED';
+
+    private function __construct() {}
+}

--- a/MangoPay/ReportRequest.php
+++ b/MangoPay/ReportRequest.php
@@ -8,14 +8,14 @@ class ReportRequest extends Libraries\EntityBase
 {
     /**
      * Date of when the report was requested.
-     * @var Timestamp
+     * @var int
      */
     public $ReportDate;
 
     /**
-     * Status of the report. 
-     * {"PENDING", "EXPIRED", "FAILED" or "READY_FOR_DOWNLOAD"}
+     * Status of the report.
      * @var string
+     * @see \MangoPay\ReportStatus
      */
     public $Status;
 
@@ -38,8 +38,9 @@ class ReportRequest extends Libraries\EntityBase
     public $CallbackURL;
 
     /**
-     * Type of the report. 
-     * @var \MangoPay\ReportType
+     * Type of the report.
+     * @var string
+     * @see \MangoPay\ReportType
      */
     public $ReportType;
 

--- a/MangoPay/ReportStatus.php
+++ b/MangoPay/ReportStatus.php
@@ -1,0 +1,12 @@
+<?php
+namespace MangoPay;
+
+final class ReportStatus
+{
+    const Pending = 'PENDING';
+    const Expired = 'EXPIRED';
+    const Failed = 'FAILED';
+    const ReadyForDownload = 'READY_FOR_DOWNLOAD';
+
+    private function __construct() {}
+}

--- a/MangoPay/Repudiation.php
+++ b/MangoPay/Repudiation.php
@@ -39,8 +39,9 @@ class Repudiation extends Libraries\EntityBase
     public $DebitedWalletId;
 
     /**
-     * The status of the transfer {CREATED, SUCCEEDED, FAILED}
-     * @var string 
+     * The status of the transfer
+     * @var string
+     * @see \MangoPay\TransactionStatus
      */
     public $Status;
 
@@ -75,11 +76,11 @@ class Repudiation extends Libraries\EntityBase
      * @var string
      */
     public $InitialTransactionId;
-    
 
     /**
      * The initial transaction type
      * @var string
+     * @see \MangoPay\TransactionType
      */
     public $InitialTransactionType;
     
@@ -93,6 +94,6 @@ class Repudiation extends Libraries\EntityBase
             'DebitedFunds' => '\MangoPay\Money',
             'Fees' => '\MangoPay\Money',
             'CreditedFunds' => '\MangoPay\Money',
-            );
+        );
     }
 }

--- a/MangoPay/Transaction.php
+++ b/MangoPay/Transaction.php
@@ -38,8 +38,8 @@ class Transaction extends Libraries\EntityBase
     public $Fees;
     
     /**
-     * TransactionStatus {CREATED, SUCCEEDED, FAILED}
      * @var string
+     * @see \MangoPay\TransactionStatus
      */
     public $Status;
     
@@ -56,20 +56,20 @@ class Transaction extends Libraries\EntityBase
     public $ResultMessage;
     
     /**
-     * Execution date;
+     * Execution date
      * @var int
      */
     public $ExecutionDate;
     
     /**
-     * TransactionType {PAYIN, PAYOUT, TRANSFER}
      * @var string
+     * @see \MangoPay\TransactionType
      */
     public $Type;
     
     /**
-     * TransactionNature { REGULAR, REFUND, REPUDIATION, SETTLEMENT }
      * @var string
+     * @see \MangoPay\TransactionNature
      */
     public $Nature;
     

--- a/MangoPay/TransactionNature.php
+++ b/MangoPay/TransactionNature.php
@@ -1,0 +1,12 @@
+<?php
+namespace MangoPay;
+
+final class TransactionNature
+{
+    const Regular = 'REGULAR';
+    const Refund = 'REFUND';
+    const Repudiation = 'REPUDIATION';
+    const Settlement = 'SETTLEMENT';
+
+    private function __construct() {}
+}

--- a/MangoPay/TransactionStatus.php
+++ b/MangoPay/TransactionStatus.php
@@ -1,0 +1,11 @@
+<?php
+namespace MangoPay;
+
+final class TransactionStatus
+{
+    const Created = 'CREATED';
+    const Succeeded = 'SUCCEEDED';
+    const Failed = 'FAILED';
+
+    private function __construct() {}
+}

--- a/MangoPay/TransactionType.php
+++ b/MangoPay/TransactionType.php
@@ -1,0 +1,11 @@
+<?php
+namespace MangoPay;
+
+final class TransactionType
+{
+    const PayIn = 'PAYIN';
+    const Transfer = 'TRANSFER';
+    const PayOut = 'PAYOUT';
+
+    private function __construct() {}
+}

--- a/MangoPay/UboDeclaration.php
+++ b/MangoPay/UboDeclaration.php
@@ -16,14 +16,15 @@ class UboDeclaration extends Libraries\EntityBase
 
     /**
      * Declaration status.
-     * @var \MangoPay\UboDeclarationStatus
+     * @var string
+     * @see \MangoPay\UboDeclarationStatus
      */
     public $Status;
 
     /**
      * List of reasons why the declaration was refused.
-     * Range of values declared in \MangoPay\UboDeclarationRefusedReasonType
-     * @var array
+     * @var string[]
+     * @see \MangoPay\UboDeclarationRefusedReasonType
      */
     public $RefusedReasonTypes;
 


### PR DESCRIPTION
This fixes https://github.com/Mangopay/mangopay2-php-sdk/pull/280#discussion_r227269705 and more importantly https://github.com/Mangopay/mangopay2-php-sdk/pull/279#discussion_r227269386. I discovered that there are many more places where this is wrong, so fixed them as well and also added a few missing `Status` and `Type` classes. I removed the string values from the doc blocks to avoid duplication and risk leaving outdated values if they ever get updated in the data class.

While working on it I tried to find more information on the `Status` property for Reports, but couldn't find any. While it exists in some code examples, it's not actually documented like the other endpoints (at least I didn't find it), e.g. `READY_FOR_DOWNLOAD` https://docs.mangopay.com/endpoints/v2.01/reporting#e824_the-report-object Would be great if we could add it there as well 🙏 