### PR TITLE
ids are not int but string

### DIFF
--- a/MangoPay/Transaction.php
+++ b/MangoPay/Transaction.php
@@ -9,13 +9,13 @@ class Transaction extends Libraries\EntityBase
 {
     /**
      * Author Id
-     * @var int
+     * @var string
      */
     public $AuthorId;
     
     /**
      * Credited user Id
-     * @var int
+     * @var string
      */
     public $CreditedUserId;
     
@@ -75,13 +75,13 @@ class Transaction extends Libraries\EntityBase
     
     /**
      * Debited wallet Id
-     * @var int
+     * @var string
      */
     public $DebitedWalletId;
     
     /**
      * Credited wallet Id
-     * @var int  
+     * @var string  
      */
     public $CreditedWalletId;
     


### PR DESCRIPTION
Follows #261, #263 and #270  on phpdoc types.

According to [the official documentation](https://docs.mangopay.com/endpoints/v2.01/transactions#e222_the-transaction-object), `DebitedWalletId`, `CreditedWalletId`, `AuthorId` and `CreditedAuthorId` are string, not int.