### PR TITLE
PHPDoc : int → string for Transfer

### DIFF
--- a/MangoPay/Transfer.php
+++ b/MangoPay/Transfer.php
@@ -8,13 +8,13 @@ class Transfer extends Transaction
 {
     /**
      * Debited wallet Id
-     * @var int
+     * @var string
      */
     public $DebitedWalletId;
     
     /**
      * Credited wallet Id
-     * @var int
+     * @var string
      */
     public $CreditedWalletId;
 }


### PR DESCRIPTION
Follows #288 and other PR about phpdoc

`Transfer::$DebitedWalletId` and `Transfer::$CreditedWalletId` are string, not int