### PR TITLE
Making the pagination information case-insensitive.

### DIFF
--- a/MangoPay/Libraries/RestTool.php
+++ b/MangoPay/Libraries/RestTool.php
@@ -214,11 +214,11 @@ class RestTool
             $logClass::Debug('Response headers', print_r($headers, true));
         }
         foreach ($headers as $header) {
-            if (strpos($header, 'X-Number-Of-Pages:') !== false) {
-                $this->_pagination->TotalPages = (int)trim(str_replace('X-Number-Of-Pages:', '', $header));
+            if (strpos(strtolower($header), 'x-number-of-pages:') !== false) {
+                $this->_pagination->TotalPages = (int)trim(str_replace('x-number-of-pages:', '', $header));
             }
-            if (strpos($header, 'X-Number-Of-Items:') !== false) {
-                $this->_pagination->TotalItems = (int)trim(str_replace('X-Number-Of-Items:', '', $header));
+            if (strpos(strtolower($header), 'x-number-of-items:') !== false) {
+            $this->_pagination->TotalItems = (int)trim(str_replace('x-number-of-items:', '', $header));
             }
             if (strpos($header, 'Link: ') !== false) {
                 $strLinks = trim(str_replace('Link:', '', $header));


### PR DESCRIPTION
As stated in #282, the pagination information is not set in the SDK. After quick debugging, it appears the problems is case-sensivity. 

Headers are present in the response in lower case, while the SDK tries to find the headers with first letter capitals. 

<img width="296" alt="screen shot 2019-02-04 at 15 24 12" src="https://user-images.githubusercontent.com/1027369/52214474-fd817700-2891-11e9-97eb-f5e2cd3c6a28.png">

This change makes the headers case-insensitive without introducing BC breaks. 