### PR TITLE
fix: pagination - total pages/items always zero

### DIFF
--- a/MangoPay/Libraries/RestTool.php
+++ b/MangoPay/Libraries/RestTool.php
@@ -221,10 +221,10 @@ class RestTool
         foreach ($headers as $header) {
             $lowercaseHeader = strtolower($header);
             if (strpos($lowercaseHeader, 'x-number-of-pages:') !== false) {
-                $this->_pagination->TotalPages = (int)trim(str_replace('x-number-of-pages:', '', $header));
+                $this->_pagination->TotalPages = (int)trim(str_replace('x-number-of-pages:', '', $lowercaseHeader));
             }
             if (strpos($lowercaseHeader, 'x-number-of-items:') !== false) {
-                $this->_pagination->TotalItems = (int)trim(str_replace('x-number-of-items:', '', $header));
+                $this->_pagination->TotalItems = (int)trim(str_replace('x-number-of-items:', '', $lowercaseHeader));
             }
             if (strpos($header, 'Link: ') !== false) {
                 $strLinks = trim(str_replace('Link:', '', $header));


### PR DESCRIPTION
The pull request #303 does not reach requirements, because $headers can be in any case and \str_replace() will search only for lower case text.
