### PR TITLE
Prevent "Creating default object from empty value"

### DIFF
--- a/MangoPay/Libraries/RestTool.php
+++ b/MangoPay/Libraries/RestTool.php
@@ -221,13 +221,13 @@ class RestTool
 
         foreach ($headers as $header) {
             $lowercaseHeader = strtolower($header);
-            if (strpos($lowercaseHeader, 'x-number-of-pages:') !== false) {
+            if (!is_null($this->_pagination) && strpos($lowercaseHeader, 'x-number-of-pages:') !== false) {
                 $this->_pagination->TotalPages = (int)trim(str_replace('x-number-of-pages:', '', $lowercaseHeader));
             }
-            if (strpos($lowercaseHeader, 'x-number-of-items:') !== false) {
+            if (!is_null($this->_pagination) && strpos($lowercaseHeader, 'x-number-of-items:') !== false) {
                 $this->_pagination->TotalItems = (int)trim(str_replace('x-number-of-items:', '', $lowercaseHeader));
             }
-            if (strpos($header, 'Link: ') !== false) {
+            if (!is_null($this->_pagination) && strpos($header, 'Link: ') !== false) {
                 $strLinks = trim(str_replace('Link:', '', $header));
                 $arrayLinks = explode(',', $strLinks);
                 if ($arrayLinks !== false) {


### PR DESCRIPTION
Sometime the backend returns pagination headers even if the request comes from ApiBase::GetObject which does not initialise a pagination object.
Because of this, we get an error "Creating default object from empty value".
For now I've only seen this happen on sandbox, but it prevents us from working.
This quick fix will just ignore the pagination headers if $this->_pagination is null.
Related issue: #197
In my case, it's happening when calling ApiUser::Get