### PR TITLE
ApiBase: add route for DirectDebitDirect object

### DIFF
--- a/MangoPay/Libraries/ApiBase.php
+++ b/MangoPay/Libraries/ApiBase.php
@@ -58,6 +58,7 @@ abstract class ApiBase
         'payins_bankwire-direct_create' => array( '/payins/bankwire/direct/', RequestType::POST ),
         'payins_directdebit-web_create' => array( '/payins/directdebit/web', RequestType::POST ),
         'payins_directdebit-direct_create' => array( '/payins/directdebit/direct', RequestType::POST ),
+        'payins_directdebitdirect-direct_create' => array( '/payins/directdebit/direct', RequestType::POST ),
         'payins_paypal-web_create' => array( '/payins/paypal/web', RequestType::POST ),
         'payins_get' => array( '/payins/%s', RequestType::GET ),
         'payins_createrefunds' => array( '/payins/%s/refunds', RequestType::POST ),


### PR DESCRIPTION
Not sure why there is 2 almost identical classes for a direct debit PayIn payment details (`PayInPaymentDetailsDirectDebit` and `PayInPaymentDetailsDirectDebit`, just one additional field for German payment services in the latter), but there were no key for `DirectDebitDirect` in `ApiBase.php`.

I don't know if one of the classes is deprecated but this is a "workaround" that may avoid errors for some people. 