### PR TITLE
[Bug Fix] fixed PayInWebExtendedView class (issue #411)

### DIFF
--- a/MangoPay/PayInWebExtendedView.php
+++ b/MangoPay/PayInWebExtendedView.php
@@ -4,7 +4,7 @@ namespace MangoPay;
 /**
  * Pay-in entity
  */
-class PayInWebExtendedView
+class PayInWebExtendedView extends Libraries\Dto
 {
     /**
      * The PayIn's ID
@@ -19,10 +19,10 @@ class PayInWebExtendedView
     public $PaymentType;
 
     /**
-     * Time when the transaction happened
-     * @var int
+     * ExecutionType { WEB, TOKEN, DIRECT, PREAUTHORIZED, RECURRING_ORDER_EXECUTION }
+     * @var string
      */
-    public $ExecutionDate;
+    public $ExecutionType;
 
     /**
      * The expiry date of the credit card (MMYY)
@@ -47,4 +47,10 @@ class PayInWebExtendedView
      * @var string
      */
     public $Country;
+
+    /**
+     * Card's fingerprint hash, unique per 16-digit card number
+     * @var string
+     */
+    public $Fingerprint;
 }


### PR DESCRIPTION
Q | A
------------ | -------------
Branch ? | Master
Bug Fix ? | Yes
New feature ? | No
Deprecation ? | No
Tickets | Fix #411 
Licence | MIT

This PR fix the current broken MangoPay\PayInWebExtendedView class as explained in issue #411
I extended PayInWebExtendedView to Libraries\Dto
In order to match the current API, I made a few changes in the class variable:
* Removed ExecutionDate (it's should not be there).
* Added ExecutionType
* Added Fingerprint
This make the mangoPayApi->PayIns->GetExtendedCardView($payIn)) call work again and sending the right information back.

## Before
```php
<?php
namespace MangoPay;

/**
 * Pay-in entity
 */
class PayInWebExtendedView
{
    /**
     * The PayIn's ID
     * @var string
     */
    public $Id;

    /**
     * Payment Type
     * @var string
     */
    public $PaymentType;

    /**
     * Time when the transaction happened
     * @var int
     */
    public $ExecutionDate;

    /**
     * The expiry date of the credit card (MMYY)
     * @var string
     */
    public $ExpirationDate;

    /**
     * A partially obfuscated version of the credit card number
     * @var object
     */
    public $Alias;

    /**
     * The card type
     * @var string
     */
    public $CardType;

    /**
     * Country of the address
     * @var string
     */
    public $Country;
}

```

## After 
```php
<?php
namespace MangoPay;

/**
 * Pay-in entity
 */
class PayInWebExtendedView extends Libraries\Dto
{
    /**
     * The PayIn's ID
     * @var string
     */
    public $Id;

    /**
     * Payment Type
     * @var string
     */
    public $PaymentType;

    /**
     * ExecutionType { WEB, TOKEN, DIRECT, PREAUTHORIZED, RECURRING_ORDER_EXECUTION }
     * @var string
     */
    public $ExecutionType;

    /**
     * The expiry date of the credit card (MMYY)
     * @var string
     */
    public $ExpirationDate;

    /**
     * A partially obfuscated version of the credit card number
     * @var object
     */
    public $Alias;

    /**
     * The card type
     * @var string
     */
    public $CardType;

    /**
     * Country of the address
     * @var string
     */
    public $Country;

    /**
     * Card's fingerprint hash, unique per 16-digit card number
     * @var string
     */
    public $Fingerprint;
}

```
## Postman Response
This is what the Mango API return using postman (**This is a test on my own MangoPay sandbox environnement**)
{{SERVER_URL}}/{{VERSION}}/{{CLIENT_ID}}/payins/card/web/{{PAYIN_ID}}/extended
```json
{
    "Id": "85712770",
    "PaymentType": "CARD",
    "ExecutionType": "WEB",
    "ExpirationDate": "1020",
    "Alias": "497010XXXXXX6588",
    "CardType": "CB_VISA_MASTERCARD",
    "Country": "FRA",
    "Fingerprint": "586d14a7ee9244dd8a7a51bb79aafc24"
}
```

## This PR Patched Response
The following is a var_dump of the expected result that this MangoPay SDK PR return on the mangoPayApi->PayIns->GetExtendedCardView($payIn)) of the same PayIn ID. 
```
object(MangoPay\PayInWebExtendedView)[76]
  public 'Id' => string '85712770' (length=8)
  public 'PaymentType' => string 'CARD' (length=4)
  public 'ExecutionType' => string 'WEB' (length=3)
  public 'ExpirationDate' => string '1020' (length=4)
  public 'Alias' => string '497010XXXXXX6588' (length=16)
  public 'CardType' => string 'CB_VISA_MASTERCARD' (length=18)
  public 'Country' => string 'FRA' (length=3)
  public 'Fingerprint' => string '586d14a7ee9244dd8a7a51bb79aafc24' (length=32)
```

## Current SDK Master response
Here is the current result (Error) of the master branch of the MangoPay SDK as stated in issue #411 
```php
In ApiBase.php line 389: Attempted to call an undefined method named "GetSubObjects" of class "MangoPay\PayInWebExtendedView".
```

Feedback welcome.