### PR TITLE
Adjusted ApiUsers::CreateKycPage() return type documentation being misleading

### DIFF
--- a/MangoPay/ApiUsers.php
+++ b/MangoPay/ApiUsers.php
@@ -288,23 +288,20 @@ class ApiUsers extends Libraries\ApiBase
      * @param string $userId User Id
      * @param string $kycDocumentId KYC Document Id
      * @param \MangoPay\KycPage $kycPage KYC Page
-     * @return bool `true` if the upload was successful, `false` otherwise
+     * @return true always true. If an error occured, a \MangoPay\Libraries\Exception is thrown
      * @throws \MangoPay\Libraries\Exception
      */
     public function CreateKycPage($userId, $kycDocumentId, $kycPage, $idempotencyKey = null)
     {
-        $uploaded = false;
         try {
-            $response = $this->CreateObject('kyc_page_create', $kycPage, null, $userId, $kycDocumentId, $idempotencyKey);
-            $uploaded = true;
+            $this->CreateObject('kyc_page_create', $kycPage, null, $userId, $kycDocumentId, $idempotencyKey);
         } catch (\MangoPay\Libraries\ResponseException $exc) {
             if ($exc->getCode() != 204) {
                 throw $exc;
-            } else {
-                $uploaded = true;
             }
         }
-        return $uploaded;
+
+        return true;
     }
 
     /**

--- a/MangoPay/ApiUsers.php
+++ b/MangoPay/ApiUsers.php
@@ -288,7 +288,7 @@ class ApiUsers extends Libraries\ApiBase
      * @param string $userId User Id
      * @param string $kycDocumentId KYC Document Id
      * @param \MangoPay\KycPage $kycPage KYC Page
-     * @return true always true. If an error occured, a \MangoPay\Libraries\Exception is thrown
+     * @return true always true. If an error occurred, a \MangoPay\Libraries\Exception is thrown
      * @throws \MangoPay\Libraries\Exception
      */
     public function CreateKycPage($userId, $kycDocumentId, $kycPage, $idempotencyKey = null)
@@ -307,9 +307,9 @@ class ApiUsers extends Libraries\ApiBase
     /**
      * Create page for Kyc document from file
      * @param string $userId User Id
-     * @param int $kycDocumentId KYC Document Id
+     * @param string $kycDocumentId KYC Document Id
      * @param string $filePath File path
-     * @return bool `true` if the upload was successful, `false` otherwise
+     * @return true always true. If an error occurred, a \MangoPay\Libraries\Exception is thrown
      * @throws \MangoPay\Libraries\Exception
      */
     public function CreateKycPageFromFile($userId, $kycDocumentId, $filePath, $idempotencyKey = null)


### PR DESCRIPTION
ApiUsers::CreateKycPage() states it can return false, but a quick glance at the possible code paths shows that it either returns true or throws.

Since all code paths that returns returns true, we can also simplify the code.