### PR TITLE
initialize Sorting::_sortFields to avoid an error when calling GetSortParameter()

### DIFF
--- a/MangoPay/Sorting.php
+++ b/MangoPay/Sorting.php
@@ -20,7 +20,7 @@ class Sorting
      * Array with fields to sort
      * @var array
      */
-    private $_sortFields;
+    private $_sortFields = [];
     
     /**
      * Add filed to sort


### PR DESCRIPTION
Maybe GetSortParameter should return an empty array if _sortFields is empty

But I think it’s good practice to have the initialize the array anyway