### PR TITLE
FIX path oauth/token erreur 404 url not found

### DIFF
--- a/MangoPay/Libraries/ApiBase.php
+++ b/MangoPay/Libraries/ApiBase.php
@@ -27,7 +27,7 @@ abstract class ApiBase
      */
     private $_methods = array(
         'authentication_base' => array('/clients/', RequestType::POST),
-        'authentication_oauth' => array('/oauth/token', RequestType::POST),
+        'authentication_oauth' => array('/oauth/token/', RequestType::POST),
 
         'responses_get' => array('/responses/%s', RequestType::GET),
 


### PR DESCRIPTION
In API DOC : https://docs.mangopay.com/guide/authentification

POST: **https://api.mangopay.com/v2.01/oauth/token/** (change the subdomain to api.sandbox... to use the sandbox environment)

Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW

Content-Type: application/x-www-form-urlencoded

Form data: grant_type=client_credentials