### PR TITLE
Ignore phpunit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ demos/paymentDirect/MangoPaySdkStorage.tmp.php
 composer.lock
 
 .idea
+
+.phpunit.result.cache


### PR DESCRIPTION
Ignore `.phpunit.result.cache` (generated when running phpunit)