### PR TITLE
Shipping must extend `Libraries\Dto` to implement GetSubObjects

### DIFF
--- a/MangoPay/Shipping.php
+++ b/MangoPay/Shipping.php
@@ -4,7 +4,7 @@
 namespace MangoPay;
 
 
-class Shipping
+class Shipping extends Libraries\Dto
 {
     /**
      * The First Name for Billing Address


### PR DESCRIPTION
The `Shipping` class implements `GetSubObjects()` without extending Libraries\Dto.
The `parent::GetSubObjects()` fails

https://github.com/Mangopay/mangopay2-php-sdk/blob/master/MangoPay/Shipping.php#L33