### PR TITLE
better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [3.5.0] - 2021-05-27
+## Added
+
+### Instant payment
+
+Mangopay introduces the instant payment mode. It allows payouts (transfer from wallet to user bank account) to be processed within 25 seconds, rather than the 48 hours for a standard payout.
+
+You can now use this new type of payout with the PHP SDK.
+
+Example :
+
+```php
+$payOutGet = $this->_api->PayOuts->GetBankwire($payOut->Id);
+// where $payOut->Id is the id of an existing payout
+```
+
+Please note that this feature must be authorized and activated by MANGOPAY. More information [here](https://docs.mangopay.com/guide/instant-payment-payout).
+
+### Accepted PRs
+
+- Improved documentation around ubo declaration reason
+- ResponseError object improvement
+
 ## [3.4.0] - 2021-05-11
 ## Fixed
 

--- a/MangoPay/Libraries/RestTool.php
+++ b/MangoPay/Libraries/RestTool.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
  */
 class RestTool
 {
-    const VERSION = '3.4.0';
+    const VERSION = '3.5.0';
 
     /**
      * Root/parent instance that holds the OAuthToken and Configuration instance
@@ -350,20 +350,36 @@ class RestTool
      */
     private function CheckResponseCode($responseCode, $response)
     {
-        if ($responseCode < 200 || $responseCode > 299) {
-            if (isset($response) && is_object($response) && isset($response->Message)) {
-                $error = new Error();
-                $error->Message = $response->Message;
-                $error->Errors = property_exists($response, 'Errors')
-                    ? $response->Errors
-                    : (property_exists($response, 'errors') ? $response->errors : null);
-                $error->Id = property_exists($response, 'Id') ? $response->Id : null;
-                $error->Type = property_exists($response, 'Type') ? $response->Type : null;
-                $error->Date = property_exists($response, 'Date') ? $response->Date : null;
-                throw new ResponseException($this->_requestUrl, $responseCode, $error);
-            } else {
-                throw new ResponseException($this->_requestUrl, $responseCode);
-            }
+        if ($responseCode >= 200 && $responseCode <= 299) {
+            return;
         }
+
+        if (!is_object($response) || !isset($response->Message)) {
+            throw new ResponseException($this->_requestUrl, $responseCode);
+        }
+
+        $error = new Error();
+
+        $map = [
+            'Message',
+            'Id',
+            'Type',
+            'Date',
+            'Errors',
+        ];
+
+        foreach ($map as $val) {
+            $error->{$val} = property_exists($response, $val) ? $response->{$val} : null;
+        }
+
+        if (property_exists($response, 'errors')) {
+            $error->Errors = $response->errors;
+        }
+
+        foreach ($error->Errors as $key => $val) {
+            $error->Message .= sprintf(' %s error: %s', $key, $val);
+        }
+
+        throw new ResponseException($this->_requestUrl, $responseCode, $error);
     }
 }

--- a/tests/Cases/ErrorTests.php
+++ b/tests/Cases/ErrorTests.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MangoPay\Tests\Cases;
+
+use MangoPay\Libraries\ResponseException;
+use MangoPay\UserNatural;
+
+class ErrorTests extends Base
+{
+    public function testThatFail()
+    {
+        $this->expectException(ResponseException::class);
+
+        try {
+            $this->_api->Users->create(new UserNatural());
+        } catch (\Exception $exception) {
+            self::assertStringContainsString('FirstName error:', $exception->getMessage());
+            self::assertStringContainsString('LastName error:', $exception->getMessage());
+            self::assertStringContainsString('Birthday error:', $exception->getMessage());
+            self::assertStringContainsString('Nationality error:', $exception->getMessage());
+            self::assertStringContainsString('CountryOfResidence error:', $exception->getMessage());
+            self::assertStringContainsString('Email error:', $exception->getMessage());
+
+            throw $exception;
+        }
+    }
+}


### PR DESCRIPTION
more accurate error messages.
I thought that it wasn't accurate enough with just 

> "One or several required parameters are missing or incorrect. An incorrect resource ID also raises this kind of error."

so I added some extra details, for example :

> "One or several required parameters are missing or incorrect. An incorrect resource ID also raises this kind of error. Address error: The value requested must be an Address object. Nationality error: The requested value is not an ISO 3166-1 alpha-2 code which is expected."

-@Rehteq
