### PR TITLE
Bug fix/restool/issue 500

### DIFF
--- a/MangoPay/ApiCards.php
+++ b/MangoPay/ApiCards.php
@@ -33,6 +33,7 @@ class ApiCards extends Libraries\ApiBase
 
     /**
      * Update card
+     * @deprecated
      * @param \MangoPay\Card $card Card object to save
      * @return \MangoPay\Card Card object returned from API
      */
@@ -76,5 +77,16 @@ class ApiCards extends Libraries\ApiBase
     public function ValidateCard($cardId)
     {
         return $this->GetObject('card_validate', '\MangoPay\Card', $cardId);
+    }
+
+    /**
+     * Deactivate a card
+     * @param \MangoPay\Card $card Card object to deactivate
+     * @return \MangoPay\Card Card object returned from API
+     * @throws Libraries\Exception
+     */
+    public function Deactivate($card)
+    {
+        return $this->SaveObject('card_save', $card, '\MangoPay\Card');
     }
 }

--- a/MangoPay/Libraries/RestTool.php
+++ b/MangoPay/Libraries/RestTool.php
@@ -376,7 +376,7 @@ class RestTool
             $error->Errors = $response->errors;
         }
 
-        foreach ($error->Errors as $key => $val) {
+        foreach ((array) $error->Errors as $key => $val) {
             $error->Message .= sprintf(' %s error: %s', $key, $val);
         }
 

--- a/tests/Cases/CardRegistrationsTest.php
+++ b/tests/Cases/CardRegistrationsTest.php
@@ -86,4 +86,21 @@ class CardRegistrationsTest extends Base
         $this->assertEquals($updatedCard->Validity, \MangoPay\CardValidity::Valid);
         $this->assertFalse($updatedCard->Active);
     }
+
+    public function test_Cards_Deactivate()
+    {
+        $cardPreAuthorization = $this->getJohnsCardPreAuthorization();
+        $card = $this->_api->Cards->Get($cardPreAuthorization->CardId);
+        $cardToDeactivate = new \MangoPay\Card();
+        $cardToDeactivate->Id = $card->Id;
+        $cardToDeactivate->Active = $card->Active;
+
+        $this->assertTrue($cardToDeactivate->Active);
+
+        $deactivatedCard = $this->_api->Cards->Deactivate($cardToDeactivate);
+
+        $this->assertFalse($deactivatedCard->Active);
+    }
+
+
 }


### PR DESCRIPTION
Q | A
------------ | -------------
Branch ? | Master
Bug Fix ? | Yes
New feature ? | No
Deprecation ? | No
Tickets | Fix #500  #506 
Licence | MIT

This PR fix the (Warning: Invalid argument supplied for foreach() in RestTool.php (line 379)) warning triggered in RestTool.php as stated in issue #500 and #506

This happen when $error->Errors is null while foreach expect an array. Add a cast (array) seem's to be a clean way to fix this.

## Code Before
```php
        foreach ($error->Errors as $key => $val) {
            $error->Message .= sprintf(' %s error: %s', $key, $val);
        }
```

## Code After 
```php
        foreach ((array) $error->Errors as $key => $val) {
            $error->Message .= sprintf(' %s error: %s', $key, $val);
        }
```

Feedback welcome :)