### PR TITLE
Bug fix/restool/issue 500 #2

### DIFF
--- a/MangoPay/Libraries/RestTool.php
+++ b/MangoPay/Libraries/RestTool.php
@@ -376,7 +376,7 @@ class RestTool
             $error->Errors = $response->errors;
         }
 
-        foreach ($error->Errors as $key => $val) {
+        foreach ((array) $error->Errors as $key => $val) {
             $error->Message .= sprintf(' %s error: %s', $key, $val);
         }
 


### PR DESCRIPTION
Q | A
------------ | -------------
Branch ? | Master
Bug Fix ? | Yes
New feature ? | No
Deprecation ? | No
Tickets | Fix #500  #506 
Licence | MIT

This PR fix the (Warning: Invalid argument supplied for foreach() in RestTool.php (line 379)) warning triggered in RestTool.php as stated in issue #500 and #506

This happen when $error->Errors is null while foreach expect an array. Add a cast (array) seem's to be a clean way to fix this.

## Code Before
```php
        foreach ($error->Errors as $key => $val) {
            $error->Message .= sprintf(' %s error: %s', $key, $val);
        }
```

## Code After 
```php
        foreach ((array) $error->Errors as $key => $val) {
            $error->Message .= sprintf(' %s error: %s', $key, $val);
        }
```

Feedback welcome :)