### PR TITLE
Fix phpdoc typehint in ReportRequest entity

### DIFF
--- a/MangoPay/ReportRequest.php
+++ b/MangoPay/ReportRequest.php
@@ -28,7 +28,7 @@ class ReportRequest extends Libraries\EntityBase
 
     /**
      * Download URL.
-     * @var string
+     * @var ?string
      */
     public $DownloadURL;
 


### PR DESCRIPTION
`ReportRequest->DownloadURL` can contains `null` after a request, when the status is `PENDING` (and probably CREATED too).

Without this, analysis tools like phpstan raise an error