### PR TITLE
Feature/recurring pay in registration

### DIFF
--- a/MangoPay/PayIn.php
+++ b/MangoPay/PayIn.php
@@ -38,6 +38,12 @@ class PayIn extends Transaction
     public $ExecutionDetails;
 
     /**
+     * Recurring PayIn Registration Id
+     * @var string
+     */
+    public $RecurringPayinRegistrationId;
+
+    /**
      * Get array with mapping which property depends on other property
      * @return array
      */

--- a/MangoPay/PayInRecurring.php
+++ b/MangoPay/PayInRecurring.php
@@ -4,8 +4,4 @@ namespace MangoPay;
 
 class PayInRecurring extends PayIn
 {
-    /**
-     * @var string
-     */
-    public $RecurringPayinRegistrationId;
 }


### PR DESCRIPTION
Q | A
------------ | -------------
Branch ? | Master
Bug Fix ? | No
New feature ? | Yes
Deprecation ? | No
Tickets | Fix #546 
Licence | MIT

This PR add the missing RecurringPayinRegistrationId to all PayIn get calls to match the MangoPay API calls.

Currently, the RecurringPayinRegistrationId is only returned when a RecurringPayinRegistration is created, there is no way to get it later on using the SDK.

I moved RecurringPayinRegistrationId from PayInRecurring class to PayIn class, and keep PayInRecurring as en empty class, just extending PayIn class, this way all the current code will still work the same and we would have a clean logic using PayInRecurring when it make sense from a code point of view, but the RecurringPayinRegistrationId value is stored in the main PayIn object / class. 

The only downside of this choice is that RecurringPayinRegistrationId is available in code completion when you create a new PayIn object which could lead to confusion.

I am happy to make changes if you see a better way to achieve this.

Cheers,

Marc



