### PR TITLE
Fix type hint for RemainingFunds

### DIFF
--- a/MangoPay/CardPreAuthorization.php
+++ b/MangoPay/CardPreAuthorization.php
@@ -138,7 +138,7 @@ class CardPreAuthorization extends Libraries\EntityBase
 
     /**
      * RemainingFunds
-     * @var string
+     * @var \MangoPay\Money
      */
     public $RemainingFunds;
 


### PR DESCRIPTION
`CardPreAuthorization::RemainingFunds` type is not a String