### PR TITLE
Add `Id` on PayInRecurringRegistration

### DIFF
--- a/MangoPay/PayInRecurringRegistration.php
+++ b/MangoPay/PayInRecurringRegistration.php
@@ -7,6 +7,11 @@ class PayInRecurringRegistration extends Libraries\Dto
     /**
      * @var string
      */
+    public $Id;
+
+    /**
+     * @var string
+     */
     public $AuthorId;
 
     /**
@@ -88,4 +93,13 @@ class PayInRecurringRegistration extends Libraries\Dto
      * @var int
      */
     public $FreeCycles;
+
+    /**
+     * Get array with read-only properties
+     * @return array
+     */
+    public function GetReadOnlyProperties()
+    {
+        return [ 'Id' ];
+    }
 }

--- a/MangoPay/PayInRecurringRegistrationRequestResponse.php
+++ b/MangoPay/PayInRecurringRegistrationRequestResponse.php
@@ -7,16 +7,6 @@ class PayInRecurringRegistrationRequestResponse extends PayInRecurringRegistrati
     /**
      * @var string
      */
-    public $Id;
-
-    /**
-     * @var string
-     */
-    public $Status;
-
-    /**
-     * @var string
-     */
     public $RecurringType;
 
     /**

--- a/tests/Cases/PayInsTest.php
+++ b/tests/Cases/PayInsTest.php
@@ -502,6 +502,7 @@ class PayInsTest extends Base
         $result = $this->getRecurringPayin();
 
         $this->assertNotNull($result);
+        $this->assertTrue($result->Id > 0);
         $this->assertNotNull($result->FreeCycles);
     }
 
@@ -513,6 +514,7 @@ class PayInsTest extends Base
         $this->assertNotNull($result);
 
         $get = $this->_api->PayIns->GetRecurringRegistration($result->Id);
+        $this->assertSame($result->Id, $get->Id);
         $this->assertNotNull($get);
 
         $this->assertNotNull($get->FreeCycles);


### PR DESCRIPTION
It's not a big issue, but when we fetch a recurringRegistration by his ID `$this->mangoPayApi->PayIns->GetRecurringRegistration('1234567');`, the result does not have the ID:

![image](https://user-images.githubusercontent.com/2025537/188416621-e4f2a175-1461-4978-a315-f0a92bb44024.png)

This could be usefull when we work with a user and we don't know if he already has a recurringRegistration or not, so if not we create it:
```php
public function getOrCreateRecurringRegistration($user): ?PayInRecurringRegistration
{
    $recurringRegistration = null;

    // Verify actual recurringRegistration
    if ($user->getRecurringRegistrationId()) {
        try {
            $recurringRegistration = $this->mangoPayApi->PayIns->GetRecurringRegistration($user->getRecurringRegistrationId());
        }catch (Exception $e) {
        }
    }

    if (null === $recurringRegistration) {
        // Return PayInRecurringRegistrationRequestResponse
        $recurringRegistration = $this->createRecurringRegistration($user);
    }

    return $recurringRegistration;
}
```

This function either return `PayInRecurringRegistrationGet` or `PayInRecurringRegistrationRequestResponse`, which both extends `PayInRecurringRegistration`, but only `PayInRecurringRegistrationRequestResponse` has `Id`

I also removed `Status` from `PayInRecurringRegistrationRequestResponse` because it's already present in `PayInRecurringRegistration`