### PR TITLE
adds missing data to requests in the workflow demo

### DIFF
--- a/demos/workflow/scripts/payin-card-direct.php
+++ b/demos/workflow/scripts/payin-card-direct.php
@@ -12,13 +12,24 @@ $PayIn->Fees->Currency = "EUR";
 $PayIn->Fees->Amount = 0;
 $PayIn->ExecutionType = \MangoPay\PayInExecutionType::Direct;
 $PayIn->ExecutionDetails = new \MangoPay\PayInExecutionDetailsDirect();
-$PayIn->ExecutionDetails->SecureModeReturnURL = "http".(isset($_SERVER['HTTPS']) ? "s" : null)."://".$_SERVER["HTTP_HOST"].$_SERVER["SCRIPT_NAME"]."?stepId=".($stepId+1);
+$PayIn->ExecutionDetails->SecureModeReturnURL = "http" . (isset($_SERVER['HTTPS']) ? "s" : null) . "://" . $_SERVER["HTTP_HOST"] . $_SERVER["SCRIPT_NAME"] . "?stepId=" . ($stepId + 1);
 $PayIn->ExecutionDetails->CardId = $_SESSION["MangoPayDemo"]["Card"];
+$PayIn->PaymentDetails->IpAddress = "2001:0620:0000:0000:0211:24FF:FE80:C12C";
+$PayIn->PaymentDetails->BrowserInfo = new \MangoPay\BrowserInfo();
+$PayIn->PaymentDetails->BrowserInfo->AcceptHeader = "text/html, application/xhtml+xml, application/xml;q=0.9, /;q=0.8";
+$PayIn->PaymentDetails->BrowserInfo->JavaEnabled = true;
+$PayIn->PaymentDetails->BrowserInfo->Language = "FR-FR";
+$PayIn->PaymentDetails->BrowserInfo->ColorDepth = 4;
+$PayIn->PaymentDetails->BrowserInfo->ScreenHeight = 1800;
+$PayIn->PaymentDetails->BrowserInfo->ScreenWidth = 400;
+$PayIn->PaymentDetails->BrowserInfo->TimeZoneOffset = 60;
+$PayIn->PaymentDetails->BrowserInfo->UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+$PayIn->PaymentDetails->BrowserInfo->JavascriptEnabled = true;
 $result = $mangoPayApi->PayIns->Create($PayIn);
 
 //Display result
 pre_dump($result);
 $_SESSION["MangoPayDemo"]["PayInCardDirect"] = $result->Id;
-if ($result->ExecutionDetails->SecureModeNeeded && $result->Status!=\MangoPay\PayInStatus::Failed) {
-	$nextButton = array("url"=>$result->ExecutionDetails->SecureModeRedirectURL, "text"=>"Go to 3DS payment page");
+if ($result->ExecutionDetails->SecureModeNeeded && $result->Status != \MangoPay\PayInStatus::Failed) {
+	$nextButton = array("url" => $result->ExecutionDetails->SecureModeRedirectURL, "text" => "Go to 3DS payment page");
 }

--- a/demos/workflow/scripts/preauth.php
+++ b/demos/workflow/scripts/preauth.php
@@ -6,13 +6,24 @@ $CardPreAuthorization->DebitedFunds->Currency = "EUR";
 $CardPreAuthorization->DebitedFunds->Amount = 1500;
 $CardPreAuthorization->SecureMode = "DEFAULT";
 $CardPreAuthorization->CardId = $_SESSION["MangoPayDemo"]["Card"];
-$CardPreAuthorization->SecureModeReturnURL = "http".(isset($_SERVER['HTTPS']) ? "s" : null)."://".$_SERVER["HTTP_HOST"].$_SERVER["SCRIPT_NAME"]."?stepId=".($stepId+1);
+$CardPreAuthorization->SecureModeReturnURL = "http" . (isset($_SERVER['HTTPS']) ? "s" : null) . "://" . $_SERVER["HTTP_HOST"] . $_SERVER["SCRIPT_NAME"] . "?stepId=" . ($stepId + 1);
+$CardPreAuthorization->IpAddress = "2001:0620:0000:0000:0211:24FF:FE80:C12C";
+$CardPreAuthorization->BrowserInfo = new \MangoPay\BrowserInfo();
+$CardPreAuthorization->BrowserInfo->AcceptHeader = "text/html, application/xhtml+xml, application/xml;q=0.9, /;q=0.8";
+$CardPreAuthorization->BrowserInfo->JavaEnabled = true;
+$CardPreAuthorization->BrowserInfo->Language = "FR-FR";
+$CardPreAuthorization->BrowserInfo->ColorDepth = 4;
+$CardPreAuthorization->BrowserInfo->ScreenHeight = 1800;
+$CardPreAuthorization->BrowserInfo->ScreenWidth = 400;
+$CardPreAuthorization->BrowserInfo->TimeZoneOffset = 60;
+$CardPreAuthorization->BrowserInfo->UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+$CardPreAuthorization->BrowserInfo->JavascriptEnabled = true;
 $result = $mangoPayApi->CardPreAuthorizations->Create($CardPreAuthorization);
 
 
 //Display result
 pre_dump($result);
 $_SESSION["MangoPayDemo"]["PreAuth"] = $result->Id;
-if ($result->SecureModeNeeded && $result->Status!=\MangoPay\CardPreAuthorizationStatus::Failed) {
-	$nextButton = array("url"=>$result->SecureModeRedirectURL, "text"=>"Go to 3DS payment page");
+if ($result->SecureModeNeeded && $result->Status != \MangoPay\CardPreAuthorizationStatus::Failed) {
+	$nextButton = array("url" => $result->SecureModeRedirectURL, "text" => "Go to 3DS payment page");
 }

--- a/demos/workflow/scripts/user-create-legal.php
+++ b/demos/workflow/scripts/user-create-legal.php
@@ -8,6 +8,18 @@ $User->LegalRepresentativeLastName = "Briant";
 $User->LegalRepresentativeBirthday = 121271;
 $User->LegalRepresentativeNationality = "FR";
 $User->LegalRepresentativeCountryOfResidence = "ZA";
+$User->CompanyNumber = 'LU123456';
+$User->UserCategory = 'Owner';
+
+$address = new \MangoPay\Address();
+$address->AddressLine1 = 'Rue des plantes';
+$address->AddressLine2 = '2nd floor';
+$address->City = 'Paris';
+$address->Country = 'FR';
+$address->PostalCode = '75000';
+$address->Region = 'IDF';
+
+$User->HeadquartersAddress = $address;
 $result = $mangoPayApi->Users->Create($User);
 
 //Display result

--- a/demos/workflow/scripts/user-create-natural.php
+++ b/demos/workflow/scripts/user-create-natural.php
@@ -6,6 +6,7 @@ $User->LastName = "Briant";
 $User->Birthday = 121271;
 $User->Nationality = "FR";
 $User->CountryOfResidence = "ZA";
+$User->UserCategory = 'Payer';
 $result = $mangoPayApi->Users->Create($User);
 
 //Display result


### PR DESCRIPTION
When going through the workflow, there are some data missing that makes the request fail. 
For example, this is returned when trying to create a natural user:
<img width="631" alt="Screenshot 2023-08-20 at 01 20 16" src="https://github.com/Mangopay/mangopay2-php-sdk/assets/62022057/4731f11d-6e84-4da6-bb93-128d3d9b596a">
