### PR TITLE
Fix idempotency response should return an Error object

### DIFF
--- a/MangoPay/ApiResponses.php
+++ b/MangoPay/ApiResponses.php
@@ -16,12 +16,20 @@ class ApiResponses extends Libraries\ApiBase
     public function Get($idempotencyKey)
     {
         $response = $this->GetObject('responses_get', 'MangoPay\Response', $idempotencyKey);
-        $className = $this->GetObjectForIdempotencyUrl($response->RequestURL);
-        if (is_null($className) || empty($className) || is_null($response->Resource) || empty($response->Resource)) {
+
+        // Same logic as RestTool::CheckResponseCode
+        if ($response->StatusCode >= 200 && $response->StatusCode <= 299) {
+            // Target the class to use from the SDK
+            $className = $this->GetObjectForIdempotencyUrl($response->RequestURL);
+            if (is_null($className) || empty($className) || is_null($response->Resource) || empty($response->Resource)) {
+                return $response;
+            }
+
+            $response->Resource = $this->CastResponseToEntity($response->Resource, $className);
             return $response;
         }
 
-        $response->Resource = $this->CastResponseToEntity($response->Resource, $className);
+        $response->Resource = $this->CastResponseToError($response->Resource);
         return $response;
     }
 }

--- a/MangoPay/Libraries/ApiBase.php
+++ b/MangoPay/Libraries/ApiBase.php
@@ -431,6 +431,41 @@ abstract class ApiBase
     }
 
     /**
+     * Cast response object to an error object
+     * @param object $response Object from API response
+     * @return Error The error
+     */
+    protected function CastResponseToError($response)
+    {
+        // This logic is similar to RestTool::CheckResponseCode
+        $error = new Error();
+
+        $map = [
+            'Message',
+            'Id',
+            'Type',
+            'Date',
+            'Errors',
+        ];
+
+        foreach ($map as $val) {
+            $error->{$val} = property_exists($response, $val) ? $response->{$val} : null;
+        }
+
+        if (property_exists($response, 'errors')) {
+            $error->Errors = $response->errors;
+        }
+
+        if (is_array($error->Errors)) {
+            foreach ($error->Errors as $key => $val) {
+                $error->Message .= sprintf(' %s error: %s', $key, $val);
+            }
+        }
+
+        return $error;
+    }
+
+    /**
      * Cast response object to entity object
      * @param object $response Object from API response
      * @param string $entityClassName Name of entity class to cast


### PR DESCRIPTION
Before this PR it would build an invalid object and get the code in trouble.
See:
```
MangoPay\Response {
  +StatusCode: "400"
  +ContentLength: ""
  +ContentType: "application/json"
  +Date: "Tue, 27 Aug 2024 09:00:05 GMT"
  +RequestURL: "https://api.sandbox.mangopay.com/v2.01/xxxx-dev/users/legal"
  +Resource: MangoPay\UserLegal {#2972
    +Id: "e97b2e7b-b5f6-4fce-8ff7-d55252da9bb1#1724749205"
    +Tag: null
    +CreationDate: null
    +PersonType: "LEGAL"
    +Email: null
    +KYCLevel: null
    +TermsAndConditionsAccepted: null
    +TermsAndConditionsAcceptedDate: null
    +UserCategory: null
    +Name: null
    +LegalPersonType: null
    +HeadquartersAddress: null
    +LegalRepresentativeFirstName: null
    +LegalRepresentativeLastName: null
    +LegalRepresentativeAddress: null
    +LegalRepresentativeEmail: null
    +LegalRepresentativeBirthday: null
    +LegalRepresentativeNationality: null
    +LegalRepresentativeCountryOfResidence: null
    +LegalRepresentativeProofOfIdentity: null
    +Statute: null
    +ProofOfRegistration: null
    +ShareholderDeclaration: null
    +CompanyNumber: null
  }
}
```
You can see that the Id is very wrong and start to understand where the problem is.
This PR fixes it.