### PR TITLE
Updates last wrongfully typed bankAccountId param to accept string

### DIFF
--- a/MangoPay/ApiUsers.php
+++ b/MangoPay/ApiUsers.php
@@ -145,7 +145,7 @@ class ApiUsers extends Libraries\ApiBase
     /**
      * Get bank account for user
      * @param string $userId User Id
-     * @param int $bankAccountId Bank account Id
+     * @param string $bankAccountId Bank account Id
      *
      * @return \MangoPay\BankAccount Entity of bank account object
      */


### PR DESCRIPTION
Checked for any usages of bankAccountId where the specified param is typed as an int. This was the only occurrence in which it was not a string.