### PR TITLE
chore: add docker-cs-fixer in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,22 @@ docker-test-php-70: ## Test on PHP 7.0
 	php-test-env:7.0 \
 	/bin/bash -c "composer update -no --no-progress --no-suggest && vendor/bin/phpunit tests"
 
-.PHONY: docker-test-php-80
-docker-test-php-80: ## Test on PHP 8.0
+.PHONY: docker-build-php-80
+docker-build-php-80:
 	docker build -t php-test-env:8.0 php_env/PHP_8.0
-	docker run -it -v "${PWD}":/usr/src/mangopay2-php-sdk \
+
+.PHONY: docker-test-php-80
+docker-test-php-80: docker-build-php-80 ## Test on PHP 8.0
+	docker run --rm -it -v "${PWD}":/usr/src/mangopay2-php-sdk \
 	-w /usr/src/mangopay2-php-sdk \
 	--user $(shell id -u):$(shell id -g) \
 	php-test-env:8.0 \
 	/bin/bash -c "composer update -no --no-progress --no-suggest --ignore-platform-reqs && vendor/bin/phpunit tests"
+
+.PHONY: docker-cs-fixer
+docker-cs-fixer: docker-build-php-80 ## Run php-cs-fixer on PHP 8.0
+	docker run --rm -it -v "${PWD}":/usr/src/mangopay2-php-sdk \
+	-w /usr/src/mangopay2-php-sdk \
+	--user $(shell id -u):$(shell id -g) \
+	php-test-env:8.0 \
+	/bin/bash -c "composer install && vendor/bin/php-cs-fixer fix"

--- a/php_env/PHP_8.0/Dockerfile
+++ b/php_env/PHP_8.0/Dockerfile
@@ -2,27 +2,30 @@ FROM php:8.0.3-cli
 
 # Update and import specific required librairies
 
-RUN apt-get update && apt-get install -y apt-utils
-RUN apt-get install -y \
-	unzip \
-	libicu-dev \
-    libonig-dev \
-	gcc \
-	wget \
-	zlib1g-dev \
-    libzip-dev
+RUN apt-get update \
+    && apt-get install -y \
+        apt-utils \
+        unzip \
+        libicu-dev \
+        libonig-dev \
+        gcc \
+        wget \
+        zlib1g-dev \
+        libzip-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Parametrize PHP
 
-RUN docker-php-ext-install mbstring
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install zip
-RUN docker-php-ext-install pcntl
-RUN docker-php-source delete
+RUN docker-php-ext-install \
+      mbstring \
+      intl \
+      zip \
+      pcntl \
+    && docker-php-source delete
 
 # Install composer
 COPY composer.sh /
-RUN chmod +x composer.sh
-RUN /composer.sh
-RUN mv composer.phar /usr/local/bin/composer
-RUN mkdir /.composer && chmod o+rwx /.composer
+RUN chmod +x composer.sh \
+    && /composer.sh \
+    && mv composer.phar /usr/local/bin/composer \
+    && mkdir /.composer && chmod o+rwx /.composer


### PR DESCRIPTION
- Allows running php-cs-fixer with docker & Makefile
- Improves PHP 8 Dockerfile (those changes could be added as well in https://github.com/Mangopay/mangopay2-php-sdk/pull/640) 