### PR TITLE
[release] 3.42.0

### DIFF
--- a/MangoPay/ApiCards.php
+++ b/MangoPay/ApiCards.php
@@ -88,4 +88,20 @@ class ApiCards extends Libraries\ApiBase
     {
         return $this->GetObject('get_card_validation', '\MangoPay\CardValidation', $cardId, $cardValidationId);
     }
+
+    /**
+     * Gets a list of transactions having for a card fingerprint.
+     * The fingerprint is a hash uniquely generated per 16-digit card number.
+     *
+     * @param string $fingerprint The fingerprint hash
+     * @param Pagination $pagination Pagination object
+     * @param Sorting $sorting Sorting object
+     * @param FilterTransactions $filter Filter object
+     * @return Transaction[] List of Transactions corresponding to provided fingerprint
+     */
+    public function GetTransactionsByFingerprint($fingerprint, $filter = null, $pagination = null, $sorting = null)
+    {
+        return $this->GetList('transactions_get_by_fingerprint', $pagination,
+            '\MangoPay\Transaction', $fingerprint, $filter, $sorting);
+    }
 }

--- a/MangoPay/EventType.php
+++ b/MangoPay/EventType.php
@@ -121,6 +121,14 @@ class EventType
     const RecurringRegistrationInProgress = "RECURRING_REGISTRATION_IN_PROGRESS";
     const InstantPayoutFailed = "INSTANT_PAYOUT_FAILED";
 
+    const ScaEnrollmentSucceeded = "SCA_ENROLLMENT_SUCCEEDED";
+    const ScaEnrollmentFailed = "SCA_ENROLLMENT_FAILED";
+    const ScaEnrollmentExpired = "SCA_ENROLLMENT_EXPIRED";
+
+    const UserCategoryUpdatedToOwner = "USER_CATEGORY_UPDATED_TO_OWNER";
+    const UserCategoryUpdatedToPayer = "USER_CATEGORY_UPDATED_TO_PAYER";
+    const UserCategoryUpdatedToPlatform = "USER_CATEGORY_UPDATED_TO_PLATFORM";
+
     const ReportGenerated = "REPORT_GENERATED";
     const ReportFailed = "REPORT_FAILED";
 }

--- a/MangoPay/Libraries/ApiBase.php
+++ b/MangoPay/Libraries/ApiBase.php
@@ -54,6 +54,7 @@ abstract class ApiBase
         'card_save' => ['/cards/%s', RequestType::PUT],
         'card_validate' => ['/cards/%s/validation', RequestType::POST],
         'get_card_validation' => ['/cards/%s/validation/%s', RequestType::GET],
+        'transactions_get_by_fingerprint' => ['/cards/fingerprints/%s/transactions', RequestType::GET],
 
         // pay ins URLs
         'payins_card-web_create' => ['/payins/card/web/', RequestType::POST],

--- a/MangoPay/Libraries/ApiBase.php
+++ b/MangoPay/Libraries/ApiBase.php
@@ -81,6 +81,7 @@ abstract class ApiBase
         'payins_ideal-web_create' => ['/payins/payment-methods/ideal', RequestType::POST],
         'payins_giropay-web_create' => ['/payins/payment-methods/giropay', RequestType::POST],
         'payins_bancontact-web_create' => ['/payins/payment-methods/bancontact', RequestType::POST],
+        'payins_bizum-web_create' => ['/payins/payment-methods/bizum', RequestType::POST],
         'payins_swish-web_create' => ['/payins/payment-methods/swish', RequestType::POST],
         'payins_twint-web_create' => ['/payins/payment-methods/twint', RequestType::POST],
         'payins_paybybank-web_create' => ['/payins/payment-methods/openbanking', RequestType::POST],

--- a/MangoPay/PayIn.php
+++ b/MangoPay/PayIn.php
@@ -78,6 +78,7 @@ class PayIn extends Transaction
                 PayInPaymentType::Ideal => 'MangoPay\PayInPaymentDetailsIdeal',
                 PayInPaymentType::Giropay => 'MangoPay\PayInPaymentDetailsGiropay',
                 PayInPaymentType::Bancontact => 'MangoPay\PayInPaymentDetailsBancontact',
+                PayInPaymentType::Bizum => 'MangoPay\PayInPaymentDetailsBizum',
                 PayInPaymentType::Swish => 'MangoPay\PayInPaymentDetailsSwish',
                 PayInPaymentType::Twint => 'MangoPay\PayInPaymentDetailsTwint',
                 PayInPaymentType::PayByBank => 'MangoPay\PayInPaymentDetailsPayByBank',

--- a/MangoPay/PayInPaymentDetailsBizum.php
+++ b/MangoPay/PayInPaymentDetailsBizum.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MangoPay;
+
+/**
+ * Class represents Bizum type for mean of payment in Bizum entity
+ */
+class PayInPaymentDetailsBizum extends Libraries\Dto implements PayInPaymentDetails
+{
+    /**
+     * The phone number of the end user to which the Bizum push notification is sent to authenticate the transaction.
+     * On Bizum, if the Phone parameter is sent, then RedirectURL is not returned and ReturnURL not required.
+     * @var string
+     */
+    public $Phone;
+
+    /**
+     * Custom description to show on the user's bank statement.
+     * It can be up to 10 char alphanumeric and space.
+     * @var string
+     */
+    public $StatementDescriptor;
+
+    /**
+     * The unique reference generated for the profiling session, used by the fraud prevention solution to produce recommendations for the transaction using the profiling data
+     * @var string
+     */
+    public $ProfilingAttemptReference;
+}

--- a/MangoPay/PayInPaymentType.php
+++ b/MangoPay/PayInPaymentType.php
@@ -25,6 +25,7 @@ class PayInPaymentType
     const Ideal = 'IDEAL';
     const Giropay = 'GIROPAY';
     const Bancontact = 'BCMC';
+    const Bizum = 'BIZUM';
     const Swish = 'SWISH';
     const Twint = 'TWINT';
     const PayByBank = 'PAY_BY_BANK';

--- a/MangoPay/UserCategory.php
+++ b/MangoPay/UserCategory.php
@@ -9,4 +9,5 @@ class UserCategory
 {
     const Payer = 'PAYER';
     const Owner = 'OWNER';
+    const Platform = 'PLATFORM';
 }

--- a/tests/Cases/Base.php
+++ b/tests/Cases/Base.php
@@ -1339,6 +1339,38 @@ abstract class Base extends TestCase
         return $this->_api->PayIns->Create($payIn);
     }
 
+    protected function getNewPayInBizumWeb($userId = null, $usePhone = true) {
+        $wallet = $this->getJohnsWalletWithMoney();
+        if (is_null($userId)) {
+            $user = $this->getJohn();
+            $userId = $user->Id;
+        }
+
+        $payIn = new \MangoPay\PayIn();
+        $payIn->AuthorId = $userId;
+        $payIn->CreditedWalletId = $wallet->Id;
+        $payIn->Fees = new \MangoPay\Money();
+        $payIn->Fees->Amount = 10;
+        $payIn->Fees->Currency = 'EUR';
+        $payIn->DebitedFunds = new \MangoPay\Money();
+        $payIn->DebitedFunds->Amount = 1000;
+        $payIn->DebitedFunds->Currency = 'EUR';
+
+        $payIn->PaymentDetails = new \MangoPay\PayInPaymentDetailsBizum();
+        $payIn->PaymentDetails->StatementDescriptor = 'Example123';
+        $payIn->ExecutionDetails = new \MangoPay\PayInExecutionDetailsWeb();
+
+        if($usePhone) {
+            $payIn->PaymentDetails->Phone = "+34700000000";
+            $payIn->Tag = "Bizum with phone tag";
+        } else {
+            $payIn->ExecutionDetails->ReturnURL = "https://docs.mangopay.com/please-ignore";
+            $payIn->Tag = "Bizum with return url tag";
+        }
+
+        return $this->_api->PayIns->Create($payIn);
+    }
+
     protected function getNewPayInPayByBankWeb($userId = null)
     {
         $wallet = $this->getJohnsWalletForCurrency("EUR");

--- a/tests/Cases/CardsTest.php
+++ b/tests/Cases/CardsTest.php
@@ -102,4 +102,16 @@ class CardsTest extends Base
             print_r("can't test due to client issues");
         }
     }
+
+    public function test_GetTransactionsByCardFingerprint()
+    {
+        $john = $this->getNewJohn();
+        $payIn = $this->getNewPayInCardDirect($john->Id);
+        $card = $this->_api->Cards->Get($payIn->PaymentDetails->CardId);
+        $transactionsByFingerprint = $this->_api->Cards->GetTransactionsByFingerprint($card->Fingerprint);
+
+        $this->assertNotNull($transactionsByFingerprint);
+        $this->assertTrue(is_array($transactionsByFingerprint), 'Expected an array');
+        $this->assertTrue(sizeof($transactionsByFingerprint) > 0);
+    }
 }

--- a/tests/Cases/PayInsTest.php
+++ b/tests/Cases/PayInsTest.php
@@ -1094,6 +1094,46 @@ class PayInsTest extends Base
         $this->assertEquals($payIn->Id, $fetchedPayIn->Id);
     }
 
+    public function test_PayIns_Create_Bizum_Web_With_Phone()
+    {
+        $payIn = $this->getNewPayInBizumWeb();
+
+        $this->assertNotNull($payIn->Id > 0);
+        $this->assertEquals(\MangoPay\PayInPaymentType::Bizum, $payIn->PaymentType);
+        $this->assertInstanceOf('\MangoPay\PayInPaymentDetailsBizum', $payIn->PaymentDetails);
+        $this->assertEquals(\MangoPay\PayInExecutionType::Web, $payIn->ExecutionType);
+        $this->assertInstanceOf('\MangoPay\PayInExecutionDetailsWeb', $payIn->ExecutionDetails);
+        $this->assertEquals(PayInStatus::Created, $payIn->Status);
+        $this->assertEquals('PAYIN', $payIn->Type);
+        $this->assertNotNull($payIn->PaymentDetails->Phone);
+
+        $fetchedPayIn = $this->_api->PayIns->Get($payIn->Id);
+        $this->assertEquals($payIn->Id, $fetchedPayIn->Id);
+        $this->assertEquals($payIn->PaymentDetails->Phone, $fetchedPayIn->PaymentDetails->Phone);
+        $this->assertNotNull($fetchedPayIn->PaymentDetails->Phone);
+        $this->assertNull($fetchedPayIn->ExecutionDetails->ReturnURL);
+    }
+
+    public function test_PayIns_Create_Bizum_Web_With_ReturnUrl()
+    {
+        $payIn = $this->getNewPayInBizumWeb(null, false);
+
+        $this->assertNotNull($payIn->Id > 0);
+        $this->assertEquals(\MangoPay\PayInPaymentType::Bizum, $payIn->PaymentType);
+        $this->assertInstanceOf('\MangoPay\PayInPaymentDetailsBizum', $payIn->PaymentDetails);
+        $this->assertEquals(\MangoPay\PayInExecutionType::Web, $payIn->ExecutionType);
+        $this->assertInstanceOf('\MangoPay\PayInExecutionDetailsWeb', $payIn->ExecutionDetails);
+        $this->assertEquals(PayInStatus::Created, $payIn->Status);
+        $this->assertEquals('PAYIN', $payIn->Type);
+        $this->assertNotNull($payIn->ExecutionDetails->ReturnURL);
+
+        $fetchedPayIn = $this->_api->PayIns->Get($payIn->Id);
+        $this->assertEquals($payIn->Id, $fetchedPayIn->Id);
+        $this->assertEquals($payIn->ExecutionDetails->ReturnURL, $fetchedPayIn->ExecutionDetails->ReturnURL);
+        $this->assertNotNull($fetchedPayIn->ExecutionDetails->ReturnURL);
+        $this->assertNull($fetchedPayIn->PaymentDetails->Phone);
+    }
+
     public function test_CardDirect_getPaymentMethodMetadata()
     {
         $payin = $this->getNewPayInCardDirect();


### PR DESCRIPTION
Added
New endpoint POST Create a Bizum PayIn
New webhook event types for SCA enrollment (API release note), note that these are triggered on enrollment not authentication:
SCA_ENROLLMENT_SUCCEEDED
SCA_ENROLLMENT_FAILED
SCA_ENROLLMENT_EXPIRED
New webhook event types for UserCategory change (API release note ):
USER_CATEGORY_UPDATED_TO_OWNER
USER_CATEGORY_UPDATED_TO_PAYER
USER_CATEGORY_UPDATED_TO_PLATFORM
Support for PLATFORM value to UserCategory enum
Support for GET List Transactions for a Card Fingerprint